### PR TITLE
Ignore failures to load openxr_forwardloader.oculus for v62+

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/vr/VrActivity.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/vr/VrActivity.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.ContextWrapper;
 import android.content.Intent;
 import android.hardware.display.DisplayManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.Display;
 import android.view.InputDevice;
@@ -25,6 +26,17 @@ public class VrActivity extends EmulationActivity {
     public static boolean hasRun = false;
     public static VrActivity currentActivity = null;
     ClickRunnable clickRunnable = new ClickRunnable();
+
+    static {
+        if (Build.BRAND.equals("oculus")) {
+            try {
+                System.loadLibrary("openxr_forwardloader.oculus");
+            } catch (UnsatisfiedLinkError e) {
+                // This was needed before v62
+                // In v62 this library is deleted
+            }
+        }
+    }
 
     public final ActivityResultLauncher<SoftwareKeyboard.KeyboardConfig> mVrKeyboardLauncher =
         registerForActivityResult(new VrKeyboardActivity.Contract(),


### PR DESCRIPTION
In v62 openxr_forwardloader.oculus.so was removed. To keep backwards compatibility with v60 there is still an attempt to load the library, but failure to do so is no longer fatal.