### PR TITLE
 Move request for microphone permission to onCreate 

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.java
@@ -184,6 +184,10 @@ public final class MainActivity extends AppCompatActivity implements MainView {
                 requestNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS);
             }
         }
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
+            // Request permission if it's not granted
+            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.RECORD_AUDIO}, 0);
+        }
         // Check for the TWO_INSTANCES string extra
         if (getIntent().getBooleanExtra(VrActivity.EXTRA_ERROR_TWO_INSTANCES, false)) {
           Log.error("Error: two instances of CitraVr::VrActivity were running at the same time!");
@@ -214,10 +218,6 @@ public final class MainActivity extends AppCompatActivity implements MainView {
     @Override
     protected void onResume() {
         super.onResume();
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
-            // Request permission if it's not granted
-            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.RECORD_AUDIO}, 0);
-        }
         mPresenter.addDirIfNeeded(new AddDirectoryHelper(this));
 
         ThemeUtil.setSystemBarMode(this, ThemeUtil.getIsLightMode(getResources()));


### PR DESCRIPTION
This request can cause issues if the user denies the microphone permission.
Calling requestPermissions causes GrantPermissionsActivity to be launched.
Citra's MainActivity will pause. GrantPermissionsActivity will immediately
finish as the user has already denied the permission. Citra's MainActivity then
gets resumed and then tries to request the permission again forming a loop.