### PR TITLE
WIP - Support for Pico 3/4 headsets

### DIFF
--- a/src/android/app/build.gradle.kts
+++ b/src/android/app/build.gradle.kts
@@ -123,6 +123,11 @@ android {
         create("nightly") {
             dimension = "version"
         }
+
+        create("pico") {
+            dimension = "version"
+            applicationIdSuffix = ".pico"
+        }
     }
 
     externalNativeBuild {

--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -52,6 +52,7 @@
         <intent>
             <action android:name="org.khronos.openxr.OpenXRApiLayerService" />
         </intent>
+        <package android:name="org.citra.citra_emu.pico" />
     </queries>
 
     <application

--- a/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.java
@@ -49,6 +49,7 @@ import org.citra.citra_emu.utils.FileBrowserHelper;
 import org.citra.citra_emu.utils.ForegroundService;
 import org.citra.citra_emu.utils.Log;
 import org.citra.citra_emu.utils.ThemeUtil;
+import org.citra.citra_emu.vr.VrActivity;
 
 import java.lang.annotation.Retention;
 import java.util.Collections;
@@ -64,6 +65,7 @@ import com.google.android.material.slider.Slider;
 public class EmulationActivity extends AppCompatActivity {
     public static final String EXTRA_SELECTED_GAME = "SelectedGame";
     public static final String EXTRA_SELECTED_TITLE = "SelectedTitle";
+    public static final String EXTRA_LAUNCH_SELECTED = "LaunchSelected";
     public static final int MENU_ACTION_EDIT_CONTROLS_PLACEMENT = 0;
     public static final int MENU_ACTION_TOGGLE_CONTROLS = 1;
     public static final int MENU_ACTION_ADJUST_SCALE = 2;

--- a/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/ui/main/MainActivity.java
@@ -199,6 +199,26 @@ public final class MainActivity extends AppCompatActivity implements MainView {
               .setPositiveButton(android.R.string.ok, null)
               .show();
         }
+
+        // Ask for storage access on legacy storage devices
+        if (VrActivity.useLegacyStorage()) {
+            String[] permissions = {
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+            };
+            if ((checkSelfPermission(permissions[0]) != PackageManager.PERMISSION_GRANTED) ||
+                (checkSelfPermission(permissions[1]) != PackageManager.PERMISSION_GRANTED)) {
+                requestPermissions(permissions, -1);
+            }
+        }
+
+        // Launch game intent
+        Intent intent = getIntent();
+        if (intent.getBooleanExtra(EmulationActivity.EXTRA_LAUNCH_SELECTED, false)) {
+            String path = intent.getStringExtra(EmulationActivity.EXTRA_SELECTED_GAME);
+            String title = intent.getStringExtra(EmulationActivity.EXTRA_SELECTED_TITLE);
+            VrActivity.launch(this, path, title);
+        }
     }
 
     @Override

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/PermissionsHandler.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/PermissionsHandler.java
@@ -13,6 +13,9 @@ import androidx.fragment.app.FragmentActivity;
 
 import org.citra.citra_emu.CitraApplication;
 import org.citra.citra_emu.R;
+import org.citra.citra_emu.vr.VrActivity;
+
+import java.io.File;
 
 public class PermissionsHandler {
     public static final String CITRA_DIRECTORY = "CITRA_DIRECTORY";
@@ -38,6 +41,9 @@ public class PermissionsHandler {
             Uri uri = getCitraDirectory();
             if (uri == null)
                 return false;
+            if (VrActivity.useLegacyStorage()) {
+                return true;
+            }
             int takeFlags = (Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
             context.getContentResolver().takePersistableUriPermission(uri, takeFlags);
             DocumentFile root = DocumentFile.fromTreeUri(context, uri);
@@ -51,11 +57,19 @@ public class PermissionsHandler {
 
     @Nullable
     public static Uri getCitraDirectory() {
-        String directoryString = mPreferences.getString(CITRA_DIRECTORY, "");
-        if (directoryString.isEmpty()) {
-            return null;
+        if (VrActivity.useLegacyStorage()) {
+            File directory = new File("/sdcard/citra-emu/");
+            if (!directory.exists()) {
+                directory.mkdir();
+            }
+            return Uri.parse(directory.getAbsolutePath());
+        } else {
+            String directoryString = mPreferences.getString(CITRA_DIRECTORY, "");
+            if (directoryString.isEmpty()) {
+                return null;
+            }
+            return Uri.parse(directoryString);
         }
-        return Uri.parse(directoryString);
     }
 
     public static boolean setCitraDirectory(String uriString) {


### PR DESCRIPTION
### Just to not set expectation too high, this is R&D, I am not sure if it is doable.

I am using two APKs approach as a workaround to a missing hybrid apps support on the headset (the first as 2D launcher and the second for OpenXR gameplay). To simplify my work, I keep using legacy storage (this will have to be resolved for Pico 5).

### TODO list
- [X] Introduce secondary APK to split 2D/VR
- [X] Add legacy storage
- [ ] OpenXR runtime loader (R&D)
- [ ] OpenXR extensions adjustment
- [ ] OpenXR controller mapping