### PR TITLE
Option to make lower panel toggleable using thumbrest as a button

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.java
@@ -433,9 +433,11 @@ public final class SettingsFragmentPresenter {
         Setting vrExtraPerformanceMode = vrSection.getSetting(SettingsFile.KEY_VR_EXTRA_PERFORMANCE_MODE);
         Setting vrCpuLevel = vrSection.getSetting(SettingsFile.KEY_VR_CPU_LEVEL);
         Setting vrImmersiveMode = vrSection.getSetting(SettingsFile.KEY_VR_IMMERSIVE_MODE);
+        Setting vrToggleableLowerPanel = vrSection.getSetting(SettingsFile.KEY_VR_TOGGLEABLE_LOWER_PANEL);
         sl.add(new SingleChoiceSetting(SettingsFile.KEY_VR_ENVIRONMENT, Settings.SECTION_VR, R.string.vr_background, 0, R.array.vrBackgroundNames, R.array.vrBackgroundValues, VRUtils.getHMDType() == VRUtils.HMDType.QUEST3.getValue() ? 1 : 2, vrEnvironment));
         sl.add(new CheckBoxSetting(SettingsFile.KEY_VR_EXTRA_PERFORMANCE_MODE, Settings.SECTION_VR, R.string.vr_extra_performance_mode, R.string.vr_extra_performance_mode_description, false, vrExtraPerformanceMode));
         sl.add(new SingleChoiceSetting(SettingsFile.KEY_VR_CPU_LEVEL, Settings.SECTION_VR, R.string.vr_cpu_level, R.string.vr_cpu_level_description, R.array.vrCpuLevelNames, R.array.vrCpuLevelValues, 4, vrCpuLevel));
         sl.add(new CheckBoxSetting(SettingsFile.KEY_VR_IMMERSIVE_MODE, Settings.SECTION_VR, R.string.vr_immersive_mode_title, R.string.vr_immersive_mode_description, false, vrImmersiveMode));
+        sl.add(new CheckBoxSetting(SettingsFile.KEY_VR_TOGGLEABLE_LOWER_PANEL, Settings.SECTION_VR, R.string.vr_toggleable_lower_panel, R.string.vr_toggleable_lower_panel_description, false, vrToggleableLowerPanel));
     }
 }

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.java
@@ -438,6 +438,6 @@ public final class SettingsFragmentPresenter {
         sl.add(new CheckBoxSetting(SettingsFile.KEY_VR_EXTRA_PERFORMANCE_MODE, Settings.SECTION_VR, R.string.vr_extra_performance_mode, R.string.vr_extra_performance_mode_description, false, vrExtraPerformanceMode));
         sl.add(new SingleChoiceSetting(SettingsFile.KEY_VR_CPU_LEVEL, Settings.SECTION_VR, R.string.vr_cpu_level, R.string.vr_cpu_level_description, R.array.vrCpuLevelNames, R.array.vrCpuLevelValues, 4, vrCpuLevel));
         sl.add(new CheckBoxSetting(SettingsFile.KEY_VR_IMMERSIVE_MODE, Settings.SECTION_VR, R.string.vr_immersive_mode_title, R.string.vr_immersive_mode_description, false, vrImmersiveMode));
-        sl.add(new CheckBoxSetting(SettingsFile.KEY_VR_TOGGLEABLE_LOWER_PANEL, Settings.SECTION_VR, R.string.vr_toggleable_lower_panel, R.string.vr_toggleable_lower_panel_description, false, vrToggleableLowerPanel));
+        sl.add(new SingleChoiceSetting(SettingsFile.KEY_VR_TOGGLEABLE_LOWER_PANEL, Settings.SECTION_VR, R.string.vr_toggleable_lower_panel, R.string.vr_toggleable_lower_panel_description, R.array.vrToggleableLowerPanelNames, R.array.vrToggleableLowerPanelValues, 0, vrToggleableLowerPanel));
     }
 }

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/utils/SettingsFile.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/utils/SettingsFile.java
@@ -136,6 +136,9 @@ public final class SettingsFile {
     public static final String KEY_VR_CPU_LEVEL = "vr_cpu_level";
 
     public static final String KEY_VR_IMMERSIVE_MODE = "vr_immersive_mode";
+
+    public static final String KEY_VR_TOGGLEABLE_LOWER_PANEL = "vr_toggleable_lower_panel";
+
     public static final String KEY_LOG_FILTER = "log_filter";
 
     private static BiMap<String, String> sectionsMap = new BiMap<>();

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -308,6 +308,10 @@ void Config::ReadValues() {
     Settings::values.vr_use_immersive_mode = sdl2_config->GetBoolean(
         "VR", "vr_immersive_mode", false);
 
+    VRSettings::values.vr_toggleable_lower_panel = sdl2_config->GetBoolean(
+        "VR", "vr_toggleable_lower_panel", false);
+    Settings::values.vr_toggleable_lower_panel = VRSettings::values.vr_toggleable_lower_panel;
+
     if (Settings::values.vr_use_immersive_mode) {
       LOG_INFO(Config, "VR immersive mode enabled");
 

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -308,8 +308,8 @@ void Config::ReadValues() {
     Settings::values.vr_use_immersive_mode = sdl2_config->GetBoolean(
         "VR", "vr_immersive_mode", false);
 
-    VRSettings::values.vr_toggleable_lower_panel = sdl2_config->GetBoolean(
-        "VR", "vr_toggleable_lower_panel", false);
+    VRSettings::values.vr_toggleable_lower_panel = sdl2_config->GetInteger(
+        "VR", "vr_toggleable_lower_panel", 0);
     Settings::values.vr_toggleable_lower_panel = VRSettings::values.vr_toggleable_lower_panel;
 
     if (Settings::values.vr_use_immersive_mode) {

--- a/src/android/app/src/main/jni/vr/XrController.cpp
+++ b/src/android/app/src/main/jni/vr/XrController.cpp
@@ -100,6 +100,9 @@ InputStateStatic::InputStateStatic(const XrInstance& instance, const XrSession& 
     mThumbClickAction = CreateAction(mActionSet, XR_ACTION_TYPE_BOOLEAN_INPUT, "thumb_click",
                                      nullptr, 2, handSubactionPaths);
 
+    mThumbRestTouchAction = CreateAction(mActionSet, XR_ACTION_TYPE_BOOLEAN_INPUT, "thumbresttouch",
+                                     nullptr, 2, handSubactionPaths);
+
     mSqueezeTriggerAction = CreateAction(mActionSet, XR_ACTION_TYPE_BOOLEAN_INPUT,
                                          "squeeze_trigger", nullptr, 2, handSubactionPaths);
 
@@ -141,6 +144,11 @@ InputStateStatic::InputStateStatic(const XrInstance& instance, const XrSession& 
         bindings.push_back(ActionSuggestedBinding(instance, mThumbClickAction,
                                                   "/user/hand/left/input/thumbstick/click"));
 
+        bindings.push_back(ActionSuggestedBinding(instance, mThumbRestTouchAction,
+                                                  "/user/hand/left/input/thumbrest/touch"));
+        bindings.push_back(ActionSuggestedBinding(instance, mThumbRestTouchAction,
+                                                  "/user/hand/right/input/thumbrest/touch"));
+
         bindings.push_back(ActionSuggestedBinding(instance, mSqueezeTriggerAction,
                                                   "/user/hand/right/input/squeeze/value"));
         bindings.push_back(ActionSuggestedBinding(instance, mSqueezeTriggerAction,
@@ -176,6 +184,7 @@ InputStateStatic::~InputStateStatic() {
     OXR(xrDestroyAction(mHandPoseAction));
     OXR(xrDestroyAction(mThumbStickAction));
     OXR(xrDestroyAction(mThumbClickAction));
+    OXR(xrDestroyAction(mThumbRestTouchAction));
     OXR(xrDestroyAction(mSqueezeTriggerAction));
 
     if (mLeftHandSpace != XR_NULL_HANDLE) {
@@ -247,6 +256,12 @@ void InputStateFrame::SyncButtonsAndThumbSticks(
         session, staticState->mThumbClickAction, staticState->mLeftHandSubactionPath);
     mThumbStickClickState[RIGHT_CONTROLLER] = SyncButtonState(
         session, staticState->mThumbClickAction, staticState->mRightHandSubactionPath);
+
+    // Sync thumbrest touch states
+    mThumbrestTouchState[LEFT_CONTROLLER] = SyncButtonState(
+        session, staticState->mThumbRestTouchAction, staticState->mLeftHandSubactionPath);
+    mThumbrestTouchState[RIGHT_CONTROLLER] = SyncButtonState(
+        session, staticState->mThumbRestTouchAction, staticState->mRightHandSubactionPath);
 
     // Sync index trigger states
     mIndexTriggerState[LEFT_CONTROLLER] = SyncButtonState(

--- a/src/android/app/src/main/jni/vr/XrController.h
+++ b/src/android/app/src/main/jni/vr/XrController.h
@@ -50,6 +50,7 @@ public:
     XrAction mHandPoseAction = XR_NULL_HANDLE;
     XrAction mThumbClickAction = XR_NULL_HANDLE;
     XrAction mSqueezeTriggerAction = XR_NULL_HANDLE;
+    XrAction mThumbRestTouchAction = XR_NULL_HANDLE;
 };
 
 struct InputStateFrame {
@@ -64,6 +65,7 @@ struct InputStateFrame {
 
     XrActionStateVector2f mThumbStickState[NUM_CONTROLLERS];
     XrActionStateBoolean mThumbStickClickState[NUM_CONTROLLERS];
+    XrActionStateBoolean mThumbrestTouchState[NUM_CONTROLLERS];
     XrActionStateBoolean mIndexTriggerState[NUM_CONTROLLERS];
     XrActionStateBoolean mSqueezeTriggerState[NUM_CONTROLLERS];
 

--- a/src/android/app/src/main/jni/vr/layers/GameSurfaceLayer.cpp
+++ b/src/android/app/src/main/jni/vr/layers/GameSurfaceLayer.cpp
@@ -341,7 +341,7 @@ void GameSurfaceLayer::Frame(const XrSpace& space, std::vector<XrCompositionLaye
      * If a mutable class member isn't desired, then just drop this bit and use the visibleLowerPanel
      * variable directly.
      */
-    const auto panelZoomSpeed = 0.1f;
+    const auto panelZoomSpeed = 0.15f; // larger = faster
     if (visibleLowerPanel && lowerPanelScaleFactor < 1.0f)
     {
         if (lowerPanelScaleFactor == 0.0f)
@@ -389,7 +389,7 @@ void GameSurfaceLayer::Frame(const XrSpace& space, std::vector<XrCompositionLaye
         layer.subImage.swapchain = swapchain_.Handle;
         layer.subImage.imageRect.offset.x =
             (cropHoriz / 2) / immersiveLevelFactor[immersiveMode_] +
-            panelWidth * (0.5f - (0.5f / immersiveLevelFactor[immersiveMode_]));
+            panelWidth * (0.5f - (0.5f / immersiveLevelFactor[immersiveMode_])) + 1;
         layer.subImage.imageRect.offset.y =
             panelHeight + verticalBorderTex +
             panelHeight * (0.5f - (0.5f / immersiveLevelFactor[immersiveMode_]));

--- a/src/android/app/src/main/jni/vr/layers/GameSurfaceLayer.cpp
+++ b/src/android/app/src/main/jni/vr/layers/GameSurfaceLayer.cpp
@@ -30,8 +30,6 @@ License     :   Licensed under GPLv3 or any later version.
 
 namespace {
 
-constexpr float lowerPanelScaleFactor = 0.75f;
-
 const std::vector<float> immersiveLevelFactor = {1.0f, 5.0f, 3.0f};
 
 /** Used to translate texture coordinates into the corresponding coordinates
@@ -236,7 +234,7 @@ GameSurfaceLayer::GameSurfaceLayer(const XrVector3f&& position, JNIEnv* env, job
     if (immersiveMode_ > 0) {
         ALOGI("Using VR immersive mode {}", immersiveMode_);
         topPanelFromWorld_.position.z = lowerPanelFromWorld_.position.z;
-        lowerPanelFromWorld_.position.y = -1.0f - (0.5f * (immersiveMode_ - 1));
+        lowerPanelFromWorld_.position.y = -1.0f;
     }
     const int32_t initializationStatus = Init(activityObject, position, session);
     if (initializationStatus < 0) {
@@ -255,7 +253,7 @@ void GameSurfaceLayer::SetSurface() const {
 }
 
 void GameSurfaceLayer::Frame(const XrSpace& space, std::vector<XrCompositionLayer>& layers,
-                             uint32_t& layerCount) const
+                             uint32_t& layerCount, const bool visibleLowerPanel) const
 
 {
     const uint32_t panelWidth = swapchain_.Width / 2;
@@ -335,6 +333,37 @@ void GameSurfaceLayer::Frame(const XrSpace& space, std::vector<XrCompositionLaye
             layers[layerCount++].mQuad = layer;
         }
     }
+
+    /*
+     * This bit is entirely optional, rather than having the panel appear/disappear it emerge in
+     * smoothly, however to achieve it I had to make the scale factor mutable, which I appreciate
+     * might not be following the intention of this class.
+     * If a mutable class member isn't desired, then just drop this bit and use the visibleLowerPanel
+     * variable directly.
+     */
+    const auto panelZoomSpeed = 0.1f;
+    if (visibleLowerPanel && lowerPanelScaleFactor < 1.0f)
+    {
+        if (lowerPanelScaleFactor == 0.0f)
+        {
+            lowerPanelScaleFactor = panelZoomSpeed;
+        }
+        else
+        {
+            lowerPanelScaleFactor *= 1.0f + panelZoomSpeed;
+            lowerPanelScaleFactor = std::min(lowerPanelScaleFactor, 1.0f);
+        }
+    }
+    else if (!visibleLowerPanel && lowerPanelScaleFactor > 0.0f)
+    {
+        lowerPanelScaleFactor /= 1.0f + panelZoomSpeed;
+        if (lowerPanelScaleFactor < panelZoomSpeed)
+        {
+            lowerPanelScaleFactor = 0.0f;
+        }
+    }
+
+
     // Create the Lower Display Panel (flat touchscreen)
     // When citra is in stereo mode, this panel is also rendered in stereo (i.e.
     // twice), but the image is mono. Therefore, take the right half of the
@@ -342,6 +371,7 @@ void GameSurfaceLayer::Frame(const XrSpace& space, std::vector<XrCompositionLaye
     // FIXME we waste rendering time rendering both displays. That said, We also
     // waste rendering time copying the buffer between runtimes. No time for
     // that now!
+    if (lowerPanelScaleFactor > 0.0f)
     {
         const uint32_t cropHoriz = 90 * resolutionFactor_;
         XrCompositionLayerQuad layer = {};
@@ -370,8 +400,8 @@ void GameSurfaceLayer::Frame(const XrSpace& space, std::vector<XrCompositionLaye
         layer.pose = lowerPanelFromWorld_;
         const auto scale = GetDensityScaleForSize(panelWidth - cropHoriz, -panelHeight,
                                                   lowerPanelScaleFactor, resolutionFactor_);
-        layer.size.width = scale.x;
-        layer.size.height = scale.y;
+        layer.size.width = scale.x * lowerPanelScaleFactor;
+        layer.size.height = scale.y * lowerPanelScaleFactor;
         layers[layerCount++].mQuad = layer;
     }
 }

--- a/src/android/app/src/main/jni/vr/layers/GameSurfaceLayer.cpp
+++ b/src/android/app/src/main/jni/vr/layers/GameSurfaceLayer.cpp
@@ -30,6 +30,9 @@ License     :   Licensed under GPLv3 or any later version.
 
 namespace {
 
+constexpr float defaultLowerPanelScaleFactor = 0.75f;
+constexpr float panelZoomSpeed = 0.15f; // larger = faster, this seems to be an agreeable number
+
 const std::vector<float> immersiveLevelFactor = {1.0f, 5.0f, 3.0f};
 
 /** Used to translate texture coordinates into the corresponding coordinates
@@ -341,8 +344,7 @@ void GameSurfaceLayer::Frame(const XrSpace& space, std::vector<XrCompositionLaye
      * If a mutable class member isn't desired, then just drop this bit and use the visibleLowerPanel
      * variable directly.
      */
-    const auto panelZoomSpeed = 0.15f; // larger = faster
-    if (visibleLowerPanel && lowerPanelScaleFactor < 1.0f)
+    if (visibleLowerPanel && lowerPanelScaleFactor < defaultLowerPanelScaleFactor)
     {
         if (lowerPanelScaleFactor == 0.0f)
         {
@@ -351,7 +353,7 @@ void GameSurfaceLayer::Frame(const XrSpace& space, std::vector<XrCompositionLaye
         else
         {
             lowerPanelScaleFactor *= 1.0f + panelZoomSpeed;
-            lowerPanelScaleFactor = std::min(lowerPanelScaleFactor, 1.0f);
+            lowerPanelScaleFactor = std::min(lowerPanelScaleFactor, defaultLowerPanelScaleFactor);
         }
     }
     else if (!visibleLowerPanel && lowerPanelScaleFactor > 0.0f)
@@ -389,7 +391,8 @@ void GameSurfaceLayer::Frame(const XrSpace& space, std::vector<XrCompositionLaye
         layer.subImage.swapchain = swapchain_.Handle;
         layer.subImage.imageRect.offset.x =
             (cropHoriz / 2) / immersiveLevelFactor[immersiveMode_] +
-            panelWidth * (0.5f - (0.5f / immersiveLevelFactor[immersiveMode_])) + 1;
+            panelWidth * (0.5f - (0.5f / immersiveLevelFactor[immersiveMode_])) +
+            (immersiveMode_ ? 1 : 0); // corrects a slight offset in immersive mode
         layer.subImage.imageRect.offset.y =
             panelHeight + verticalBorderTex +
             panelHeight * (0.5f - (0.5f / immersiveLevelFactor[immersiveMode_]));

--- a/src/android/app/src/main/jni/vr/layers/GameSurfaceLayer.h
+++ b/src/android/app/src/main/jni/vr/layers/GameSurfaceLayer.h
@@ -98,9 +98,10 @@ public:
      * center of the layer is placed in the center of the FOV.
      *  @param layers the array of layers to populate
      *  @param layerCount the number of layers in the array
+     *  @param visibleLowerPanel whether the lower panel is shown/visible
      */
     void Frame(const XrSpace& space, std::vector<XrCompositionLayer>& layers,
-               uint32_t& layerCount) const;
+               uint32_t& layerCount, const bool visibleLowerPanel) const;
 
     /** Given an origin, direction of a ray,
      *  returns the coordinates of where the ray will intersects
@@ -169,6 +170,11 @@ private:
     //   - Multiview (requires a merged Citra/CitraVR renderer)
     //   - Rendering the top-screen and bottom screen separately.
     const uint32_t immersiveMode_;
+
+    // Used to nicely present the lower panel when in toggleable mode.
+    // Instead of it just appearing instantly, it emerges in a hopefully pleasant
+    // fashion
+    mutable float lowerPanelScaleFactor = 1.0f;
 
     //============================
     // JNI objects

--- a/src/android/app/src/main/jni/vr/layers/GameSurfaceLayer.h
+++ b/src/android/app/src/main/jni/vr/layers/GameSurfaceLayer.h
@@ -174,7 +174,7 @@ private:
     // Used to nicely present the lower panel when in toggleable mode.
     // Instead of it just appearing instantly, it emerges in a hopefully pleasant
     // fashion
-    mutable float lowerPanelScaleFactor = 1.0f;
+    mutable float lowerPanelScaleFactor = 0.0f;
 
     //============================
     // JNI objects

--- a/src/android/app/src/main/jni/vr/vr_main.cpp
+++ b/src/android/app/src/main/jni/vr/vr_main.cpp
@@ -489,7 +489,7 @@ private:
             layers[layerCount++].Passthrough = passthroughLayer;
         }
 
-        if (VRSettings::values.vr_toggleable_lower_panel)
+        if (VRSettings::values.vr_toggleable_lower_panel == 1)
         {
             if (mInputStateFrame.mThumbrestTouchState[InputStateFrame::LEFT_CONTROLLER].currentState ||
                 mInputStateFrame.mThumbrestTouchState[InputStateFrame::RIGHT_CONTROLLER].currentState)
@@ -504,6 +504,11 @@ private:
             {
                 mTogglingLowerPanel = false;
             }
+        }
+        else if (VRSettings::values.vr_toggleable_lower_panel == 2)
+        {
+            mVisibleLowerPanel = (mInputStateFrame.mThumbrestTouchState[InputStateFrame::LEFT_CONTROLLER].currentState ||
+                mInputStateFrame.mThumbrestTouchState[InputStateFrame::RIGHT_CONTROLLER].currentState);
         }
 
         const bool visibleLowerPanel = !VRSettings::values.vr_toggleable_lower_panel || mVisibleLowerPanel;

--- a/src/android/app/src/main/jni/vr/vr_main.cpp
+++ b/src/android/app/src/main/jni/vr/vr_main.cpp
@@ -489,7 +489,26 @@ private:
             layers[layerCount++].Passthrough = passthroughLayer;
         }
 
-        mGameSurfaceLayer->Frame(gOpenXr->localSpace_, layers, layerCount);
+        if (VRSettings::values.vr_toggleable_lower_panel)
+        {
+            if (mInputStateFrame.mThumbrestTouchState[InputStateFrame::LEFT_CONTROLLER].currentState ||
+                mInputStateFrame.mThumbrestTouchState[InputStateFrame::RIGHT_CONTROLLER].currentState)
+            {
+                if (!mTogglingLowerPanel)
+                {
+                    mVisibleLowerPanel = !mVisibleLowerPanel;
+                    mTogglingLowerPanel = true;
+                }
+            }
+            else
+            {
+                mTogglingLowerPanel = false;
+            }
+        }
+
+        const bool visibleLowerPanel = !VRSettings::values.vr_toggleable_lower_panel || mVisibleLowerPanel;
+
+        mGameSurfaceLayer->Frame(gOpenXr->localSpace_, layers, layerCount, visibleLowerPanel);
 #if defined(UI_LAYER)
         if (gShouldShowErrorMessage) {
             XrCompositionLayerQuad quadLayer = {};
@@ -857,6 +876,9 @@ private:
     jmethodID mResumeGameMethodID = nullptr;
     jmethodID mPauseGameMethodID = nullptr;
     jmethodID mOpenSettingsMethodID = nullptr;
+
+    bool mTogglingLowerPanel = false;
+    bool mVisibleLowerPanel = true;
 };
 
 struct VRAppHandle {

--- a/src/android/app/src/main/jni/vr/vr_settings.h
+++ b/src/android/app/src/main/jni/vr/vr_settings.h
@@ -43,6 +43,7 @@ struct Values {
     int32_t vr_environment = 0;
     bool extra_performance_mode_enabled = false;
     int32_t vr_immersive_mode = 0;
+    bool vr_toggleable_lower_panel = false;
 } extern values;
 
 } // namespace VRSettings

--- a/src/android/app/src/main/jni/vr/vr_settings.h
+++ b/src/android/app/src/main/jni/vr/vr_settings.h
@@ -43,7 +43,7 @@ struct Values {
     int32_t vr_environment = 0;
     bool extra_performance_mode_enabled = false;
     int32_t vr_immersive_mode = 0;
-    bool vr_toggleable_lower_panel = false;
+    int32_t vr_toggleable_lower_panel = 0;
 } extern values;
 
 } // namespace VRSettings

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -224,4 +224,16 @@
         <item>3</item>
         <item>4</item>
     </integer-array>
+
+    <string-array name="vrToggleableLowerPanelNames">
+        <item>Always Visible</item>
+        <item>Toggle Visibility on Thumbrest Touch</item>
+        <item>Visible only when Thumbrest Touched</item>
+    </string-array>
+
+    <integer-array name="vrToggleableLowerPanelValues">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </integer-array>
 </resources>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -298,6 +298,8 @@
     <string name="vr_error_two_instances_message">Detected a fatal launch bug with CitraVR.  This is a known issue. \n\nThe problem is now resolved.   Please try launching the game again. </string>
     <string name="vr_extra_performance_mode_description">Overrides the value of other settings to minimize overhead and maxmimize performance.  NOTE: when this setting is enabled, the user\'s values for the following settings are ignored: VR Environment (always selects "Void"), all audio (disabled)</string>
     <string name="vr_extra_performance_mode">VR Extra Performance Mode</string>
+    <string name="vr_toggleable_lower_panel_description">VR Toggle visibility of the lower panel when the tumbrest is touched on either controller</string>
+    <string name="vr_toggleable_lower_panel">VR Toggleable Lower Panel</string>
     <string name="vr_cpu_level">CPU level</string>
     <string name="vr_cpu_level_description">Higher levels may improve audio/emulation performance, but will drain the battery faster</string>
     <string name="vr_immersive_mode_title">(Experimental): VR180 Immersive Mode</string>

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -528,7 +528,7 @@ struct Values {
 
     // VR
     Setting<bool> vr_use_immersive_mode{false, "vr_immersive_mode"};
-    Setting<bool> vr_toggleable_lower_panel{false, "vr_toggleable_lower_panel"};
+    Setting<u32> vr_toggleable_lower_panel{0, "vr_toggleable_lower_panel"};
 };
 
 extern Values values;

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -528,6 +528,7 @@ struct Values {
 
     // VR
     Setting<bool> vr_use_immersive_mode{false, "vr_immersive_mode"};
+    Setting<bool> vr_toggleable_lower_panel{false, "vr_toggleable_lower_panel"};
 };
 
 extern Values values;

--- a/src/video_core/rasterizer_accelerated.cpp
+++ b/src/video_core/rasterizer_accelerated.cpp
@@ -4,6 +4,7 @@
 
 #include <limits>
 #include "common/alignment.h"
+#include "common/settings.h"
 #include "core/memory.h"
 #include "video_core/pica_state.h"
 #include "video_core/rasterizer_accelerated.h"
@@ -136,6 +137,7 @@ void RasterizerAccelerated::SyncEntireState() {
 
     // Sync uniforms
     SyncClipPlane();
+    SyncVRImmersive();
     SyncDepthScale();
     SyncDepthOffset();
     SyncAlphaTest();
@@ -858,6 +860,11 @@ void RasterizerAccelerated::SyncClipPlane() {
         vs_uniform_block_data.data.clip_coef = new_clip_coef;
         vs_uniform_block_data.dirty = true;
     }
+}
+
+void RasterizerAccelerated::SyncVRImmersive() {
+    vs_uniform_block_data.data.vr_use_immersive_mode = Settings::values.vr_use_immersive_mode.GetValue();
+    vs_uniform_block_data.dirty = true;
 }
 
 } // namespace VideoCore

--- a/src/video_core/rasterizer_accelerated.h
+++ b/src/video_core/rasterizer_accelerated.h
@@ -103,6 +103,9 @@ protected:
     /// Syncs the clip plane state to match the PICA register
     void SyncClipPlane();
 
+    /// Syncs the VR immersive flag
+    void SyncVRImmersive();
+
 protected:
     /// Structure that keeps tracks of the vertex shader uniform state
     struct VSUniformBlockData {

--- a/src/video_core/shader/generator/glsl_shader_gen.cpp
+++ b/src/video_core/shader/generator/glsl_shader_gen.cpp
@@ -43,6 +43,7 @@ layout (set = 0, binding = 1, std140) uniform vs_data {
 #else
 layout (binding = 1, std140) uniform vs_data {
 #endif
+    bool vr_use_immersive_mode;
     bool enable_clip1;
     vec4 clip_coef;
 };
@@ -1681,12 +1682,7 @@ void main() {
     }
 )";
 
-    if (!Settings::values.vr_use_immersive_mode.GetValue())
-    {
-        out+= "\ngl_Position = vec4(vtx_pos.x, vtx_pos.y, -vtx_pos.z, vtx_pos.w);\n";
-    } else {
-        out+= "\ngl_Position = vec4(vtx_pos.x / 3.0, vtx_pos.y / 3.0, -vtx_pos.z, vtx_pos.w);\n";
-    }
+    out+= "\ngl_Position = vec4(vtx_pos.x, vtx_pos.y, -vtx_pos.z, vtx_pos.w);\n";
 
     if (use_clip_planes) {
         out += R"(
@@ -1807,14 +1803,7 @@ std::string GenerateVertexShader(const Pica::Shader::ShaderSetup& setup, const P
         out += "        vtx_pos.z = 0.f;\n";
         out += "    }\n";
 
-        if (!Settings::values.vr_use_immersive_mode.GetValue())
-        {
-              out+= "    gl_Position = vec4(vtx_pos.x, vtx_pos.y, -vtx_pos.z, vtx_pos.w);\n";
-        }
-        else
-        {
-              out+= "    gl_Position = vec4(vtx_pos.x / 3.0, vtx_pos.y / 3.0, -vtx_pos.z, vtx_pos.w);\n";
-        }
+        out+= "    gl_Position = vec4(vtx_pos.x, vtx_pos.y, -vtx_pos.z, vtx_pos.w);\n";
 
         if (config.state.use_clip_planes) {
             out += "    gl_ClipDistance[0] = -vtx_pos.z;\n"; // fixed PICA clipping plane z <= 0
@@ -1913,11 +1902,11 @@ struct Vertex {
     out += "        vtx_pos.z = 0.f;\n";
     out += "    }\n";
 
-    if (!Settings::values.vr_use_immersive_mode.GetValue()) {
-        out+= "    gl_Position = vec4(vtx_pos.x, vtx_pos.y, -vtx_pos.z, vtx_pos.w);\n";
-    } else {
-        out+= "    gl_Position = vec4(vtx_pos.x / 3.0, vtx_pos.y / 3.0, -vtx_pos.z, vtx_pos.w);\n";
-    }
+    out += "    if (vr_use_immersive_mode) {\n";
+    out += "        gl_Position = vec4(vtx_pos.x / 3.0, vtx_pos.y / 3.0, -vtx_pos.z, vtx_pos.w);\n";
+    out += "    } else {\n";
+    out += "        gl_Position = vec4(vtx_pos.x, vtx_pos.y, -vtx_pos.z, vtx_pos.w);\n";
+    out += "    }\n\n";
 
     if (state.use_clip_planes) {
         out += "    gl_ClipDistance[0] = -vtx_pos.z;\n"; // fixed PICA clipping plane z <= 0

--- a/src/video_core/shader/generator/shader_gen.cpp
+++ b/src/video_core/shader/generator/shader_gen.cpp
@@ -21,8 +21,6 @@ PicaFSConfig::PicaFSConfig(const Pica::Regs& regs, bool has_fragment_shader_inte
                                      ? regs.framebuffer.output_merger.alpha_test.func.Value()
                                      : Pica::FramebufferRegs::CompareFunc::Always);
 
-    state.vr_use_immersive_mode.Assign(Settings::values.vr_use_immersive_mode.GetValue());
-
     state.texture0_type.Assign(regs.texturing.texture0.type);
 
     state.texture2_use_coord1.Assign(regs.texturing.main_config.texture2_use_coord1 != 0);
@@ -270,8 +268,6 @@ void PicaVSConfigState::Init(const Pica::Regs& regs, Pica::Shader::ShaderSetup& 
     if (!use_geometry_shader_) {
         gs_state.Init(regs, use_clip_planes_);
     }
-
-    vr_use_immersive_mode = Settings::values.vr_use_immersive_mode.GetValue();
 }
 
 PicaVSConfig::PicaVSConfig(const Pica::Regs& regs, Pica::Shader::ShaderSetup& setup,

--- a/src/video_core/shader/generator/shader_gen.h
+++ b/src/video_core/shader/generator/shader_gen.h
@@ -60,7 +60,6 @@ struct PicaFSConfigState {
         BitField<28, 1, u32> shadow_texture_orthographic;
         BitField<29, 1, u32> use_fragment_shader_interlock;
         BitField<30, 1, u32> use_custom_normal_map;
-        BitField<31, 1, u32> vr_use_immersive_mode;
     };
 
     union {
@@ -216,8 +215,6 @@ struct PicaVSConfigState {
     std::array<u32, 16> output_map;
 
     PicaGSConfigState gs_state;
-
-    bool vr_use_immersive_mode;
 
 };
 

--- a/src/video_core/shader/generator/shader_uniforms.h
+++ b/src/video_core/shader/generator/shader_uniforms.h
@@ -89,6 +89,7 @@ struct PicaUniformsData {
 };
 
 struct VSUniformData {
+    bool vr_use_immersive_mode;
     bool enable_clip1;
     alignas(16) Common::Vec4f clip_coef;
 };


### PR DESCRIPTION
Great for Immersvive Mode!

I moved the lower panel back to its original position which would make it fairly intrusive, but it can now be toggled off (zooming away in a pleasant fashion), so now you can race in Mario Kart 7 (for example) without seeing the lower panel out of the corner of your eye, but it can be called upon easily enough when needed. It's optional, but I didn't restrict it to immersive mode in case there was some occasion where someone wants to play without the lower panel being visible.

I appreciate you are in the middle of merging the upstream Citra changes, so don't feel this needs to be merged in any time soon. I won't keep sending random PRs over either, this just happened to be a bit of functionality I wanted for Mario Kart so thought I would implement it 😄 