### PR TITLE
Pass the vr_use_immersive_mode as a Vertex Shader Uniform flag

### DIFF
--- a/src/video_core/rasterizer_accelerated.cpp
+++ b/src/video_core/rasterizer_accelerated.cpp
@@ -4,6 +4,7 @@
 
 #include <limits>
 #include "common/alignment.h"
+#include "common/settings.h"
 #include "core/memory.h"
 #include "video_core/pica_state.h"
 #include "video_core/rasterizer_accelerated.h"
@@ -136,6 +137,7 @@ void RasterizerAccelerated::SyncEntireState() {
 
     // Sync uniforms
     SyncClipPlane();
+    SyncVRImmersive();
     SyncDepthScale();
     SyncDepthOffset();
     SyncAlphaTest();
@@ -858,6 +860,11 @@ void RasterizerAccelerated::SyncClipPlane() {
         vs_uniform_block_data.data.clip_coef = new_clip_coef;
         vs_uniform_block_data.dirty = true;
     }
+}
+
+void RasterizerAccelerated::SyncVRImmersive() {
+    vs_uniform_block_data.data.vr_use_immersive_mode = Settings::values.vr_use_immersive_mode.GetValue();
+    vs_uniform_block_data.dirty = true;
 }
 
 } // namespace VideoCore

--- a/src/video_core/rasterizer_accelerated.h
+++ b/src/video_core/rasterizer_accelerated.h
@@ -103,6 +103,9 @@ protected:
     /// Syncs the clip plane state to match the PICA register
     void SyncClipPlane();
 
+    /// Syncs the VR immersive flag
+    void SyncVRImmersive();
+
 protected:
     /// Structure that keeps tracks of the vertex shader uniform state
     struct VSUniformBlockData {

--- a/src/video_core/shader/generator/glsl_shader_gen.cpp
+++ b/src/video_core/shader/generator/glsl_shader_gen.cpp
@@ -43,6 +43,7 @@ layout (set = 0, binding = 1, std140) uniform vs_data {
 #else
 layout (binding = 1, std140) uniform vs_data {
 #endif
+    bool vr_use_immersive_mode;
     bool enable_clip1;
     vec4 clip_coef;
 };
@@ -1681,12 +1682,7 @@ void main() {
     }
 )";
 
-    if (!Settings::values.vr_use_immersive_mode.GetValue())
-    {
-        out+= "\ngl_Position = vec4(vtx_pos.x, vtx_pos.y, -vtx_pos.z, vtx_pos.w);\n";
-    } else {
-        out+= "\ngl_Position = vec4(vtx_pos.x / 3.0, vtx_pos.y / 3.0, -vtx_pos.z, vtx_pos.w);\n";
-    }
+    out+= "\ngl_Position = vec4(vtx_pos.x, vtx_pos.y, -vtx_pos.z, vtx_pos.w);\n";
 
     if (use_clip_planes) {
         out += R"(
@@ -1807,14 +1803,7 @@ std::string GenerateVertexShader(const Pica::Shader::ShaderSetup& setup, const P
         out += "        vtx_pos.z = 0.f;\n";
         out += "    }\n";
 
-        if (!Settings::values.vr_use_immersive_mode.GetValue())
-        {
-              out+= "    gl_Position = vec4(vtx_pos.x, vtx_pos.y, -vtx_pos.z, vtx_pos.w);\n";
-        }
-        else
-        {
-              out+= "    gl_Position = vec4(vtx_pos.x / 3.0, vtx_pos.y / 3.0, -vtx_pos.z, vtx_pos.w);\n";
-        }
+        out+= "    gl_Position = vec4(vtx_pos.x, vtx_pos.y, -vtx_pos.z, vtx_pos.w);\n";
 
         if (config.state.use_clip_planes) {
             out += "    gl_ClipDistance[0] = -vtx_pos.z;\n"; // fixed PICA clipping plane z <= 0
@@ -1913,11 +1902,11 @@ struct Vertex {
     out += "        vtx_pos.z = 0.f;\n";
     out += "    }\n";
 
-    if (!Settings::values.vr_use_immersive_mode.GetValue()) {
-        out+= "    gl_Position = vec4(vtx_pos.x, vtx_pos.y, -vtx_pos.z, vtx_pos.w);\n";
-    } else {
-        out+= "    gl_Position = vec4(vtx_pos.x / 3.0, vtx_pos.y / 3.0, -vtx_pos.z, vtx_pos.w);\n";
-    }
+    out += "    if (vr_use_immersive_mode) {\n";
+    out += "        gl_Position = vec4(vtx_pos.x / 3.0, vtx_pos.y / 3.0, -vtx_pos.z, vtx_pos.w);\n";
+    out += "    } else {\n";
+    out += "        gl_Position = vec4(vtx_pos.x, vtx_pos.y, -vtx_pos.z, vtx_pos.w);\n";
+    out += "    }\n\n";
 
     if (state.use_clip_planes) {
         out += "    gl_ClipDistance[0] = -vtx_pos.z;\n"; // fixed PICA clipping plane z <= 0

--- a/src/video_core/shader/generator/shader_gen.cpp
+++ b/src/video_core/shader/generator/shader_gen.cpp
@@ -21,8 +21,6 @@ PicaFSConfig::PicaFSConfig(const Pica::Regs& regs, bool has_fragment_shader_inte
                                      ? regs.framebuffer.output_merger.alpha_test.func.Value()
                                      : Pica::FramebufferRegs::CompareFunc::Always);
 
-    state.vr_use_immersive_mode.Assign(Settings::values.vr_use_immersive_mode.GetValue());
-
     state.texture0_type.Assign(regs.texturing.texture0.type);
 
     state.texture2_use_coord1.Assign(regs.texturing.main_config.texture2_use_coord1 != 0);
@@ -270,8 +268,6 @@ void PicaVSConfigState::Init(const Pica::Regs& regs, Pica::Shader::ShaderSetup& 
     if (!use_geometry_shader_) {
         gs_state.Init(regs, use_clip_planes_);
     }
-
-    vr_use_immersive_mode = Settings::values.vr_use_immersive_mode.GetValue();
 }
 
 PicaVSConfig::PicaVSConfig(const Pica::Regs& regs, Pica::Shader::ShaderSetup& setup,

--- a/src/video_core/shader/generator/shader_gen.h
+++ b/src/video_core/shader/generator/shader_gen.h
@@ -60,7 +60,6 @@ struct PicaFSConfigState {
         BitField<28, 1, u32> shadow_texture_orthographic;
         BitField<29, 1, u32> use_fragment_shader_interlock;
         BitField<30, 1, u32> use_custom_normal_map;
-        BitField<31, 1, u32> vr_use_immersive_mode;
     };
 
     union {
@@ -216,8 +215,6 @@ struct PicaVSConfigState {
     std::array<u32, 16> output_map;
 
     PicaGSConfigState gs_state;
-
-    bool vr_use_immersive_mode;
 
 };
 

--- a/src/video_core/shader/generator/shader_uniforms.h
+++ b/src/video_core/shader/generator/shader_uniforms.h
@@ -89,6 +89,7 @@ struct PicaUniformsData {
 };
 
 struct VSUniformData {
+    bool vr_use_immersive_mode;
     bool enable_clip1;
     alignas(16) Common::Vec4f clip_coef;
 };


### PR DESCRIPTION
This means the same shaders can be used for both immersive and non-immersive as the uniform itself is the toggle in the GLSL rather than generating two different instances of the shader. 

Furthermore, only one place where the gl_Position was being modified was actually needed; the other two seem to be able to be removed without it preventing immersive mode from working.

Hopefully this change will help make it easier to merge immersive to the main branch as it will now longer cause shader cache issues for anyone.