### PR TITLE
Jd 6dof

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
@@ -38,7 +38,7 @@ enum class IntSetting(
     CUSTOM_TEXTURES("custom_textures", Settings.SECTION_UTILITY, 0),
     ASYNC_CUSTOM_LOADING("async_custom_loading", Settings.SECTION_UTILITY, 1),
     PRELOAD_TEXTURES("preload_textures", Settings.SECTION_UTILITY, 0),
-    ENABLE_AUDIO_STRETCHING("enable_audio_stretching", Settings.SECTION_AUDIO, 1),
+    ENABLE_AUDIO_STRETCHING("enable_audio_stretching", Settings.SECTION_AUDIO, 0),
     CPU_JIT("use_cpu_jit", Settings.SECTION_CORE, 1),
     HW_SHADER("use_hw_shader", Settings.SECTION_RENDERER, 1),
     VSYNC("use_vsync_new", Settings.SECTION_RENDERER, 1),

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
@@ -31,7 +31,7 @@ enum class IntSetting(
     NEW_3DS("is_new_3ds", Settings.SECTION_SYSTEM, 1),
     LLE_APPLETS("lle_applets", Settings.SECTION_SYSTEM, 0),
     CPU_CLOCK_SPEED("cpu_clock_percentage", Settings.SECTION_CORE, 100),
-    LINEAR_FILTERING("filter_mode", Settings.SECTION_RENDERER, 1),
+    LINEAR_FILTERING("filter_mode", Settings.SECTION_RENDERER, 0),
     SHADERS_ACCURATE_MUL("shaders_accurate_mul", Settings.SECTION_RENDERER, 0),
     DISK_SHADER_CACHE("use_disk_shader_cache", Settings.SECTION_RENDERER, 1),
     DUMP_TEXTURES("dump_textures", Settings.SECTION_UTILITY, 0),

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -758,7 +758,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     R.string.factor3d,
                     R.string.factor3d_description,
                     0,
-                    100,
+                    300,
                     "%",
                     IntSetting.STEREOSCOPIC_3D_DEPTH.key,
                     IntSetting.STEREOSCOPIC_3D_DEPTH.defaultValue.toFloat()

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/SystemFilesFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/SystemFilesFragment.kt
@@ -38,6 +38,7 @@ import org.citra.citra_emu.utils.SystemSaveGame
 import org.citra.citra_emu.viewmodel.GamesViewModel
 import org.citra.citra_emu.viewmodel.HomeViewModel
 import org.citra.citra_emu.viewmodel.SystemFilesViewModel
+import org.citra.citra_emu.vr.VrActivity
 
 class SystemFilesFragment : Fragment() {
     private var _binding: FragmentSystemFilesBinding? = null
@@ -206,8 +207,9 @@ class SystemFilesFragment : Fragment() {
                 path = menuPath,
                 filename = ""
             )
-            val action = HomeNavigationDirections.actionGlobalEmulationActivity(menu)
-            binding.root.findNavController().navigate(action)
+          //  val action = HomeNavigationDirections.actionGlobalEmulationActivity(menu)
+         //   binding.root.findNavController().navigate(action)
+            VrActivity.launch(CitraApplication.appContext, menu.path, menu.title)
         }
     }
 

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -294,12 +294,14 @@ void Config::ReadValues() {
       LOG_INFO(Config, "VR immersive mode enabled");
 
       // no point rendering passthrough in immersive mode
-      VRSettings::values.vr_environment =
-        static_cast<uint32_t>(VRSettings::VREnvironmentType::VOID);
+      // JLD: disagree. disabling this override.
+      // VRSettings::values.vr_environment =
+      //  static_cast<uint32_t>(VRSettings::VREnvironmentType::VOID);
       // We originally had two immersive modes, but I cut them down to fit in
       // the shader map's bitfield.
-      VRSettings::values.vr_immersive_mode = 2;
+      VRSettings::values.vr_immersive_mode = 1;
       // When immersive mode is enabled, only OpenGL is supported.
+      // FOR NOW :)
       Settings::values.graphics_api = Settings::GraphicsAPI::OpenGL;
     }
 

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -161,7 +161,7 @@ bg_blue =
 bg_green =
 
 # Change 3D Intensity
-# 0 - 100: Intensity. 0 (default)
+# 0 - 300: Intensity. 50 (default)
 # factor_3d =50
 
 # The name of the post processing shader to apply.

--- a/src/android/app/src/main/jni/vr/vr_main.cpp
+++ b/src/android/app/src/main/jni/vr/vr_main.cpp
@@ -888,6 +888,7 @@ Java_org_citra_citra_1emu_vr_VrActivity_nativeOnCreate(JNIEnv* env, jobject thiz
     JavaVM* jvm;
     env->GetJavaVM(&jvm);
     auto ret = VRAppHandle(new VRApp(jvm, env->NewGlobalRef(thiz))).l;
+    ALOGI("nativeOnCreate {}", ret);
     return ret;
 }
 

--- a/src/android/app/src/main/jni/vr/vr_main.cpp
+++ b/src/android/app/src/main/jni/vr/vr_main.cpp
@@ -744,10 +744,10 @@ private:
     void HandleSessionStateChangedEvent(const XrEventDataSessionStateChanged& newState) {
         static XrSessionState lastState = XR_SESSION_STATE_UNKNOWN;
         if (newState.state != lastState) {
-            ALOGV("{}(): Received XR_SESSION_STATE_CHANGED state {}->{} "
-                  "session={} time={}",
-                  __func__, XrSessionStateToString(lastState),
-                  XrSessionStateToString(newState.state), newState.session, newState.time);
+//            ALOGV("{}(): Received XR_SESSION_STATE_CHANGED state {}->{} "
+//                  "session={} time={}",
+//                  __func__, XrSessionStateToString(lastState),
+//                  XrSessionStateToString(newState.state), newState.session, newState.time);
         }
         lastState = newState.state;
         switch (newState.state) {

--- a/src/android/app/src/main/jni/vr/vr_main.cpp
+++ b/src/android/app/src/main/jni/vr/vr_main.cpp
@@ -888,7 +888,6 @@ Java_org_citra_citra_1emu_vr_VrActivity_nativeOnCreate(JNIEnv* env, jobject thiz
     JavaVM* jvm;
     env->GetJavaVM(&jvm);
     auto ret = VRAppHandle(new VRApp(jvm, env->NewGlobalRef(thiz))).l;
-    ALOGI("amwatson nativeOnCreate {}", ret);
     return ret;
 }
 

--- a/src/android/app/src/main/res/values-de/strings.xml
+++ b/src/android/app/src/main/res/values-de/strings.xml
@@ -520,7 +520,6 @@
     <string name="vr_background">VR -Umgebung</string>
     <string name="vr_error_two_instances_title">Fehler: Erkennete zwei CitraVR -Instanzen</string>
     <string name="vr_error_two_instances_message">Erkannte einen tödlichen Startfehler mit CitraVR. Dies ist ein bekanntes Problem. \n\nDas Problem ist jetzt gelöst. Bitte versuchen Sie, das Spiel erneut zu starten. </string>
-    <string name="vr_extra_performance_mode_description">Überschreibt den Wert anderer Einstellungen, um den Overhead zu minimieren und die Leistung zu maximieren. Hinweis: Wenn diese Einstellung aktiviert ist, werden die Werte des Benutzers für die folgenden Einstellungen ignoriert: VR -Umgebung (wählt immer "void"), alle Audio (deaktiviert). </string>
     <string name="vr_extra_performance_mode">VR zusätzlicher Leistungsmodus</string>
     <string name="vr_cpu_level">CPU -Ebene</string>
     <string name="vr_cpu_level_description">Höhere Werte können die Audio-/Emulationsleistung verbessern, die Batterie jedoch schneller abtropfen lassen</string>
@@ -532,4 +531,5 @@
     <string name="release_notes_title">Versionshinweise</string>
     <string name="vr_licenses_description">Projekte, die Citra und Citravr ermöglichen</string>
     <string name="game_compat_tooltip">Spielkompatibilitätsblatt</string>
+    <string name="vr_extra_performance_mode_description">Überschreibt den Wert anderer Einstellungen, um den Overhead zu minimieren und die Leistung zu maximieren. HINWEIS: Wenn diese Einstellung aktiviert ist, werden die Werte des Benutzers für die folgenden Einstellungen ignoriert: VR -Umgebung (wählt immer void), Audio -Dehnung (deaktiviert). </string>
 </resources>

--- a/src/android/app/src/main/res/values-es/strings.xml
+++ b/src/android/app/src/main/res/values-es/strings.xml
@@ -662,7 +662,6 @@ Se esperan fallos gráficos temporales cuando ésta esté activado.</string>
     <string name="vr_background">Entorno de realidad virtual</string>
     <string name="vr_error_two_instances_title">Error: detectó dos instancias CitraVR</string>
     <string name="vr_error_two_instances_message">Detectó un error de lanzamiento fatal con CitraVR. Este es un problema conocido. \n\nEl problema ahora se resuelve. Intente volver a lanzar el juego. </string>
-    <string name="vr_extra_performance_mode_description">Anula el valor de otras configuraciones para minimizar los gastos generales y maxmimizar el rendimiento. Nota: Cuando esta configuración está habilitada, se ignoran los valores del usuario para la siguiente configuración: entorno VR (siempre selecciona "nulo"), todo audio (deshabilitado)</string>
     <string name="vr_extra_performance_mode">Modo de rendimiento adicional VR</string>
     <string name="vr_cpu_level">Nivel de la CPU</string>
     <string name="vr_cpu_level_description">Los niveles más altos pueden mejorar el rendimiento de audio/emulación, pero drenarán la batería más rápido</string>
@@ -674,4 +673,5 @@ Se esperan fallos gráficos temporales cuando ésta esté activado.</string>
     <string name="release_notes_title">Notas de lanzamiento</string>
     <string name="vr_licenses_description">Proyectos que hacen posible a Citra y Citravr</string>
     <string name="game_compat_tooltip">Hoja de compatibilidad del juego</string>
+    <string name="vr_extra_performance_mode_description">Anula el valor de otras configuraciones para minimizar los gastos generales y maxmimizar el rendimiento. Nota: Cuando esta configuración está habilitada, se ignoran los valores del usuario para la siguiente configuración: entorno VR (siempre selecciona void), estiramiento de audio (deshabilitado)</string>
 </resources>

--- a/src/android/app/src/main/res/values-fi/strings.xml
+++ b/src/android/app/src/main/res/values-fi/strings.xml
@@ -97,7 +97,6 @@
     <string name="vr_background">VR -ympäristö</string>
     <string name="vr_error_two_instances_title">VIRHE: havaitsi kaksi CitraVR -tapausta</string>
     <string name="vr_error_two_instances_message">Havaitsi kohtalokkaan käynnistysvirheen CitraVR: n kanssa. Tämä on tunnettu asia. \n\nongelma on nyt ratkaistu. Yritä käynnistää peli uudelleen. </string>
-    <string name="vr_extra_performance_mode_description">Ohittaa muiden asetusten arvon yleiskustannusten minimoimiseksi ja suorituskyvyn maksimimiseksi. HUOMAUTUS: Kun tämä asetus on käytössä, seuraavien asetusten käyttäjän arvot jätetään huomiotta: VR -ympäristö (valitsee aina "tyhjä"), kaikki ääni (käytöstä poistettu)</string>
     <string name="vr_extra_performance_mode">VR Extra Performance -tila</string>
     <string name="vr_cpu_level">CPU -taso</string>
     <string name="vr_cpu_level_description">Korkeammat tasot voivat parantaa audio/emulointia, mutta tyhjentää akun nopeammin</string>
@@ -109,4 +108,5 @@
     <string name="release_notes_title">Julkaisutiedot</string>
     <string name="vr_licenses_description">Projektit, jotka tekevät Citrasta ja Citravrista mahdolliseksi</string>
     <string name="game_compat_tooltip">Pelin yhteensopivuuslomake</string>
+    <string name="vr_extra_performance_mode_description">Ohittaa muiden asetusten arvon yleiskustannusten minimoimiseksi ja suorituskyvyn maksimimiseksi. Huomaa: Kun tämä asetus on käytössä, seuraavien asetusten käyttäjän arvot jätetään huomiotta: VR -ympäristö (valittuu aina tyhjä), äänen venytys (pois käytöstä)</string>
 </resources>

--- a/src/android/app/src/main/res/values-fr/strings.xml
+++ b/src/android/app/src/main/res/values-fr/strings.xml
@@ -663,7 +663,6 @@
     <string name="vr_background">Environnement VR</string>
     <string name="vr_error_two_instances_title">Erreur: détecté deux instances CitraVR</string>
     <string name="vr_error_two_instances_message">Détecté un bogue de lancement fatal avec CitraVR. C\'est un problème connu. \n\nLe problème est désormais résolu. Veuillez essayer de lancer à nouveau le jeu. </string>
-    <string name="vr_extra_performance_mode_description">Recouvre la valeur des autres paramètres pour minimiser les frais généraux et les performances maxonimiales. Remarque: Lorsque ce paramètre est activé, les valeurs de l\'utilisateur pour les paramètres suivants sont ignorées: Environnement VR (Sélectionne toujours "void"), tout l\'audio (désactivé)</string>
     <string name="vr_extra_performance_mode">Mode de performance supplémentaire VR</string>
     <string name="vr_cpu_level">Niveau du processeur</string>
     <string name="vr_cpu_level_description">Des niveaux plus élevés peuvent améliorer les performances audio / émulation, mais draineront la batterie plus rapidement</string>
@@ -675,4 +674,5 @@
     <string name="release_notes_title">Notes de version</string>
     <string name="vr_licenses_description">Les projets qui rendent Citra et Citravr possible</string>
     <string name="game_compat_tooltip">Feuille de compatibilité du jeu</string>
+    <string name="vr_extra_performance_mode_description">Recouvre la valeur des autres paramètres pour minimiser les frais généraux et les performances maxonimiales. Remarque: Lorsque ce paramètre est activé, les valeurs de l\'utilisateur pour les paramètres suivants sont ignorées: Environnement VR (Sélectionne toujours void), étirement audio (désactivé)</string>
 </resources>

--- a/src/android/app/src/main/res/values-it/strings.xml
+++ b/src/android/app/src/main/res/values-it/strings.xml
@@ -251,7 +251,6 @@
     <string name="vr_background">Ambiente VR</string>
     <string name="vr_error_two_instances_title">Errore: rilevato due istanze CitraVR</string>
     <string name="vr_error_two_instances_message">Ho rilevato un bug di lancio fatale con CitraVR. Questo è un problema noto. \n\nIl problema è ora risolto. Prova a lanciare di nuovo il gioco. </string>
-    <string name="vr_extra_performance_mode_description">Scora il valore di altre impostazioni per ridurre al minimo le prestazioni generali e maxmimizza. Nota: quando questa impostazione è abilitata, i valori dell\'utente per le seguenti impostazioni vengono ignorati: Ambiente VR (seleziona sempre "vuoto"), tutto audio (disabilitato)</string>
     <string name="vr_extra_performance_mode">Modalità di prestazione extra VR</string>
     <string name="vr_cpu_level">Livello CPU</string>
     <string name="vr_cpu_level_description">Livelli più alti possono migliorare le prestazioni audio/emulazione, ma prosciugheranno la batteria più velocemente</string>
@@ -263,4 +262,5 @@
     <string name="release_notes_title">Note di rilascio</string>
     <string name="vr_licenses_description">Progetti che rendono possibili Citra e Citravr</string>
     <string name="game_compat_tooltip">Foglio di compatibilità del gioco</string>
+    <string name="vr_extra_performance_mode_description">Scora il valore di altre impostazioni per ridurre al minimo le prestazioni generali e maxmimizza. NOTA: quando questa impostazione è abilitata, i valori dell\'utente per le seguenti impostazioni vengono ignorati: VR Environment (seleziona sempre il vuoto), Stretching audio (disabilitato)</string>
 </resources>

--- a/src/android/app/src/main/res/values-ja/strings.xml
+++ b/src/android/app/src/main/res/values-ja/strings.xml
@@ -114,7 +114,6 @@
     <string name="vr_background">VR環境</string>
     <string name="vr_error_two_instances_title">エラー：2つのCitraVRインスタンスを検出しました</string>
     <string name="vr_error_two_instances_message">CitraVRを使用した致命的な打ち上げバグを検出しました。これは既知の問題です。\n\n問題が解決されました。もう一度ゲームを起動してみてください。</string>
-    <string name="vr_extra_performance_mode_description">オーバーヘッドを最小限に抑え、パフォーマンスを最大化するために、他の設定の値をオーバーライドします。注：この設定が有効になっている場合、次の設定のユーザーの値は無視されます：VR環境（常に「void」を選択）、すべてのオーディオ（無効）</string>
     <string name="vr_extra_performance_mode">VR追加パフォーマンスモード</string>
     <string name="vr_cpu_level">CPUレベル</string>
     <string name="vr_cpu_level_description">より高いレベルはオーディオ/エミュレーションのパフォーマンスを改善する可能性がありますが、バッテリーをより速く排出します</string>
@@ -126,4 +125,5 @@
     <string name="release_notes_title">リリースノート</string>
     <string name="vr_licenses_description">CitraとCitravrを可能にするプロジェクト</string>
     <string name="game_compat_tooltip">ゲーム互換シート</string>
+    <string name="vr_extra_performance_mode_description">オーバーヘッドを最小限に抑え、パフォーマンスを最大化するために、他の設定の値をオーバーライドします。注：この設定が有効になっている場合、次の設定のユーザーの値は無視されます：VR環境（常にボイドを選択）、オーディオストレッチング（無効）</string>
     </resources>

--- a/src/android/app/src/main/res/values-ko/strings.xml
+++ b/src/android/app/src/main/res/values-ko/strings.xml
@@ -171,7 +171,6 @@
     <string name="vr_background">VR 환경</string>
     <string name="vr_error_two_instances_title">오류 : 두 개의 CitraVR 인스턴스를 감지했습니다</string>
     <string name="vr_error_two_instances_message">CitraVR로 치명적인 발사 버그를 감지했습니다. 이것은 알려진 문제입니다. \n\n이제 문제가 해결되었습니다. 게임을 다시 시작하십시오. </string>
-    <string name="vr_extra_performance_mode_description">오버 헤드를 최소화하고 성능을 최대화하기 위해 다른 설정의 값을 무시합니다. 참고 :이 설정이 활성화되면 다음 설정에 대한 사용자의 값은 무시됩니다.  VR 환경 (항상 "void"를 선택), 모든 오디오 (비활성화)</string>
     <string name="vr_extra_performance_mode">VR 추가 성능 모드</string>
     <string name="vr_cpu_level">CPU 레벨</string>
     <string name="vr_cpu_level_description">레벨이 높을수록 오디오/에뮬레이션 성능이 향상 될 수 있지만 배터리가 더 빨리 배터리를 배출합니다. </string>
@@ -183,4 +182,5 @@
     <string name="release_notes_title">릴리즈 노트</string>
     <string name="vr_licenses_description">Citra와 Citravr을 가능하게하는 프로젝트</string>
     <string name="game_compat_tooltip">게임 호환 시트</string>
+    <string name="vr_extra_performance_mode_description">오버 헤드를 최소화하고 성능을 최대화하기 위해 다른 설정의 값을 무시합니다. 참고 :이 설정이 활성화되면 다음 설정에 대한 사용자의 값은 무시됩니다.  VR 환경 (항상 void를 선택), 오디오 스트레칭 (비활성화)</string>
 </resources>

--- a/src/android/app/src/main/res/values-nb/strings.xml
+++ b/src/android/app/src/main/res/values-nb/strings.xml
@@ -169,7 +169,6 @@
     <string name="vr_background">VR -miljø</string>
     <string name="vr_error_two_instances_title">Feil: oppdaget to CitraVR -forekomster</string>
     <string name="vr_error_two_instances_message">Oppdaget en dødelig lanseringsfeil med CitraVR. Dette er et kjent spørsmål. \n\nProblemet er nå løst. Vennligst prøv å starte spillet igjen. </string>
-    <string name="vr_extra_performance_mode_description">Overstyrer verdien av andre innstillinger for å minimere overhead og maksimalisere ytelsen. Merk: Når denne innstillingen er aktivert, blir brukerens verdier for følgende innstillinger ignorert: VR -miljø (velger alltid "Void"), All Audio (deaktivert)</string>
     <string name="vr_extra_performance_mode">VR Extra Performance Mode</string>
     <string name="vr_cpu_level">CPU -nivå</string>
     <string name="vr_cpu_level_description">Høyere nivåer kan forbedre ytelsen til lyd/emulering, men vil tømme batteriet raskere</string>
@@ -181,4 +180,5 @@
     <string name="release_notes_title">Utgivelsesnotater</string>
     <string name="vr_licenses_description">Prosjekter som gjør citra og citravr mulig</string>
     <string name="game_compat_tooltip">Spillkompatibilitetsark</string>
+    <string name="vr_extra_performance_mode_description">Overstyrer verdien av andre innstillinger for å minimere overhead og maksimalisere ytelsen. Merk: Når denne innstillingen er aktivert, blir brukerens verdier for følgende innstillinger ignorert: VR -miljø (velger alltid tomrom), lydstrekking (deaktivert)</string>
 </resources>

--- a/src/android/app/src/main/res/values-pt/strings.xml
+++ b/src/android/app/src/main/res/values-pt/strings.xml
@@ -322,7 +322,6 @@
     <string name="vr_background">Ambiente VR</string>
     <string name="vr_error_two_instances_title">Erro: detectado duas instâncias de CitraVR</string>
     <string name="vr_error_two_instances_message">Detectou um bug de lançamento fatal com CitraVR. Este é um problema conhecido. \n\nO problema agora está resolvido. Por favor, tente lançar o jogo novamente. </string>
-    <string name="vr_extra_performance_mode_description">Substitui o valor de outras configurações para minimizar a sobrecarga e maximizar o desempenho. Nota: Quando essa configuração é ativada, os valores do usuário para as seguintes configurações são ignorados: o ambiente VR (sempre seleciona "void"), todo o áudio (desativado)</string>
     <string name="vr_extra_performance_mode">VR Modo de desempenho extra</string>
     <string name="vr_cpu_level">Nível da CPU</string>
     <string name="vr_cpu_level_description">Níveis mais altos podem melhorar o desempenho de áudio/emulação, mas drenará a bateria mais rapidamente</string>
@@ -334,4 +333,5 @@
     <string name="release_notes_title">Notas de liberação</string>
     <string name="vr_licenses_description">Projetos que tornam possível o Citra e Citravr</string>
     <string name="game_compat_tooltip">Folha de compatibilidade de jogos</string>
+    <string name="vr_extra_performance_mode_description">Substitui o valor de outras configurações para minimizar a sobrecarga e maximizar o desempenho. Nota: Quando essa configuração é ativada, os valores do usuário para as seguintes configurações são ignorados: ambiente VR (sempre seleciona o vazio), alongamento de áudio (desativado)</string>
 </resources>

--- a/src/android/app/src/main/res/values-zh/strings.xml
+++ b/src/android/app/src/main/res/values-zh/strings.xml
@@ -660,7 +660,6 @@
     <string name="vr_background">VR环境</string>
     <string name="vr_error_two_instances_title">错误：检测到两个CitraVR实例</string>
     <string name="vr_error_two_instances_message">通过CitraVR检测到致命的发射错误。这是一个已知的问题。\n\n现在解决了问题。请尝试再次启动游戏。</string>
-    <string name="vr_extra_performance_mode_description">覆盖其他设置的价值，以最大程度地减少开销并最大程度地提高性能。注意：启用此设置后，忽略了以下设置的用户值：VR环境（始终选择“ void”），所有音频（禁用）</string>
     <string name="vr_extra_performance_mode">VR额外的性能模式</string>
     <string name="vr_cpu_level">CPU级别</string>
     <string name="vr_cpu_level_description">较高的水平可以改善音频/仿真性能，但会更快地排出电池</string>
@@ -672,4 +671,5 @@
     <string name="release_notes_title">发行说明</string>
     <string name="vr_licenses_description">使Citra和Citravr成为可能的项目</string>
     <string name="game_compat_tooltip">游戏兼容性表</string>
+    <string name="vr_extra_performance_mode_description">覆盖其他设置的价值，以最大程度地减少开销并最大程度地提高性能。注意：启用此设置后，忽略了以下设置的用户值：VR环境（始终选择void），音频拉伸（禁用）</string>
 </resources>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -691,5 +691,5 @@
     <string name="release_notes_title">Release Notes</string>
     <string name="vr_licenses_description">Projects that make Citra and CitraVR possible</string>
     <string name="game_compat_tooltip">Game Compatibility Sheet</string>
-    <string name="vr_extra_performance_mode_description">Overrides the value of other settings to minimize overhead and maxmimize performance.  NOTE: when this setting is enabled, the user\\'s values for the following settings are ignored: VR Environment (always selects Void), Audio stretching (disabled)</string>
+    <string name="vr_extra_performance_mode_description">Overrides the value of other settings to minimize overhead and maxmimize performance.  NOTE: when this setting is enabled, the user\'s values for the following settings are ignored: VR Environment (always selects Void), Audio stretching (disabled)</string>
 </resources>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -679,7 +679,6 @@
     <string name="vr_keyboard_right">&gt;</string>
     <string name="vr_error_two_instances_title">Error: Detected Two CitraVR Instances</string>
     <string name="vr_error_two_instances_message">Detected a fatal launch bug with CitraVR.  This is a known issue. \n\nThe problem is now resolved.   Please try launching the game again. </string>
-    <string name="vr_extra_performance_mode_description">Overrides the value of other settings to minimize overhead and maxmimize performance.  NOTE: when this setting is enabled, the user\'s values for the following settings are ignored: VR Environment (always selects "Void"), all audio (disabled)</string>
     <string name="vr_extra_performance_mode">VR Extra Performance Mode</string>
     <string name="vr_cpu_level">CPU level</string>
     <string name="vr_cpu_level_description">Higher levels may improve audio/emulation performance, but will drain the battery faster</string>
@@ -692,4 +691,5 @@
     <string name="release_notes_title">Release Notes</string>
     <string name="vr_licenses_description">Projects that make Citra and CitraVR possible</string>
     <string name="game_compat_tooltip">Game Compatibility Sheet</string>
+    <string name="vr_extra_performance_mode_description">Overrides the value of other settings to minimize overhead and maxmimize performance.  NOTE: when this setting is enabled, the user\\'s values for the following settings are ignored: VR Environment (always selects Void), Audio stretching (disabled)</string>
 </resources>

--- a/src/android/build.gradle.kts
+++ b/src/android/build.gradle.kts
@@ -4,8 +4,8 @@
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.1.2" apply false
-    id("com.android.library") version "8.1.2" apply false
+    id("com.android.application") version "8.2.2" apply false
+    id("com.android.library") version "8.2.2" apply false
     id("org.jetbrains.kotlin.android") version "1.8.21" apply false
     id("org.jetbrains.kotlin.plugin.serialization") version "1.8.21"
 }

--- a/src/android/gradle/wrapper/gradle-wrapper.properties
+++ b/src/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -160,7 +160,7 @@ bg_green =
 render_3d =
 
 # Change 3D Intensity
-# 0 - 100: Intensity. 0 (default)
+# 0 - 300: Intensity. 50 (default)
 factor_3d =
 
 # Change Default Eye to Render When in Monoscopic Mode

--- a/src/citra_qt/configuration/configure_enhancements.ui
+++ b/src/citra_qt/configuration/configure_enhancements.ui
@@ -271,7 +271,7 @@
            <number>0</number>
           </property>
           <property name="maximum">
-           <number>100</number>
+           <number>300</number>
           </property>
           <property name="value">
            <number>0</number>

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -509,7 +509,7 @@ struct Values {
     Setting<s32> cardboard_x_shift{0, "cardboard_x_shift"};
     Setting<s32> cardboard_y_shift{0, "cardboard_y_shift"};
 
-    SwitchableSetting<bool> filter_mode{true, "filter_mode"};
+    SwitchableSetting<bool> filter_mode{false, "filter_mode"};
     SwitchableSetting<std::string> pp_shader_name{"none (builtin)", "pp_shader_name"};
     SwitchableSetting<std::string> anaglyph_shader_name{"dubois (builtin)", "anaglyph_shader_name"};
 

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -521,7 +521,7 @@ struct Values {
     // Audio
     bool audio_muted;
     SwitchableSetting<AudioEmulation> audio_emulation{AudioEmulation::HLE, "audio_emulation"};
-    SwitchableSetting<bool> enable_audio_stretching{true, "enable_audio_stretching"};
+    SwitchableSetting<bool> enable_audio_stretching{false, "enable_audio_stretching"};
     SwitchableSetting<float, true> volume{1.f, 0.f, 1.f, "volume"};
     Setting<AudioCore::SinkType> output_type{AudioCore::SinkType::Auto, "output_type"};
     Setting<std::string> output_device{"auto", "output_device"};

--- a/src/video_core/shader/generator/glsl_shader_gen.cpp
+++ b/src/video_core/shader/generator/glsl_shader_gen.cpp
@@ -312,6 +312,11 @@ void main() {
         std::string out = GetVertexInterfaceDeclaration(true, state.use_clip_planes, separable_shader);
         out += VSUniformBlockDef;
 
+        // Declare your variables here
+        out += "uniform float vr_immersive_mode_factor;\n";
+        out += "uniform mat4 projection;\n";
+        out += "uniform vec3 vr_position;\n";
+
         out += '\n';
         for (u32 i = 0; i < state.vs_output_attributes; ++i) {
             if (separable_shader) {

--- a/src/video_core/shader/generator/glsl_shader_gen.cpp
+++ b/src/video_core/shader/generator/glsl_shader_gen.cpp
@@ -15,7 +15,7 @@ using VSOutputAttributes = Pica::RasterizerRegs::VSOutputAttributes;
 
 namespace Pica::Shader::Generator::GLSL {
 
-constexpr std::string_view VSPicaUniformBlockDef = R"(
+    constexpr std::string_view VSPicaUniformBlockDef = R"(
 struct pica_uniforms {
     bool b[16];
     uvec4 i[4];
@@ -31,7 +31,7 @@ layout (binding = 0, std140) uniform vs_pica_data {
 };
 )";
 
-constexpr std::string_view VSUniformBlockDef = R"(
+    constexpr std::string_view VSUniformBlockDef = R"(
 #ifdef VULKAN
 layout (set = 0, binding = 1, std140) uniform vs_data {
 #else
@@ -55,66 +55,66 @@ vec4 SanitizeVertex(vec4 vtx_pos) {
 }
 )";
 
-static std::string GetVertexInterfaceDeclaration(bool is_output, bool use_clip_planes,
-                                                 bool separable_shader) {
-    std::string out;
+    static std::string GetVertexInterfaceDeclaration(bool is_output, bool use_clip_planes,
+                                                     bool separable_shader) {
+        std::string out;
 
-    const auto append_variable = [&](std::string_view var, int location) {
-        if (separable_shader) {
-            out += fmt::format("layout (location={}) ", location);
-        }
-        out += fmt::format("{}{};\n", is_output ? "out " : "in ", var);
-    };
+        const auto append_variable = [&](std::string_view var, int location) {
+            if (separable_shader) {
+                out += fmt::format("layout (location={}) ", location);
+            }
+            out += fmt::format("{}{};\n", is_output ? "out " : "in ", var);
+        };
 
-    append_variable("vec4 primary_color", ATTRIBUTE_COLOR);
-    append_variable("vec2 texcoord0", ATTRIBUTE_TEXCOORD0);
-    append_variable("vec2 texcoord1", ATTRIBUTE_TEXCOORD1);
-    append_variable("vec2 texcoord2", ATTRIBUTE_TEXCOORD2);
-    append_variable("float texcoord0_w", ATTRIBUTE_TEXCOORD0_W);
-    append_variable("vec4 normquat", ATTRIBUTE_NORMQUAT);
-    append_variable("vec3 view", ATTRIBUTE_VIEW);
+        append_variable("vec4 primary_color", ATTRIBUTE_COLOR);
+        append_variable("vec2 texcoord0", ATTRIBUTE_TEXCOORD0);
+        append_variable("vec2 texcoord1", ATTRIBUTE_TEXCOORD1);
+        append_variable("vec2 texcoord2", ATTRIBUTE_TEXCOORD2);
+        append_variable("float texcoord0_w", ATTRIBUTE_TEXCOORD0_W);
+        append_variable("vec4 normquat", ATTRIBUTE_NORMQUAT);
+        append_variable("vec3 view", ATTRIBUTE_VIEW);
 
-    if (is_output && separable_shader) {
-        // gl_PerVertex redeclaration is required for separate shader object
-        out += "out gl_PerVertex {\n";
-        // Apple Silicon GPU drivers optimize more aggressively, which can create
-        // too much variance and cause visual artifacting in games like Pokemon.
+        if (is_output && separable_shader) {
+            // gl_PerVertex redeclaration is required for separate shader object
+            out += "out gl_PerVertex {\n";
+            // Apple Silicon GPU drivers optimize more aggressively, which can create
+            // too much variance and cause visual artifacting in games like Pokemon.
 #ifdef __APPLE__
-        out += "    invariant vec4 gl_Position;\n";
+            out += "    invariant vec4 gl_Position;\n";
 #else
-        out += "    vec4 gl_Position;\n";
+            out += "    vec4 gl_Position;\n";
 #endif
-        if (use_clip_planes) {
-            out += "    float gl_ClipDistance[2];\n";
+            if (use_clip_planes) {
+                out += "    float gl_ClipDistance[2];\n";
+            }
+            out += "};\n";
         }
-        out += "};\n";
+
+        return out;
     }
 
-    return out;
-}
+    std::string GenerateTrivialVertexShader(bool use_clip_planes, bool separable_shader) {
+        std::string out;
+        if (separable_shader) {
+            out += "#extension GL_ARB_separate_shader_objects : enable\n";
+        }
 
-std::string GenerateTrivialVertexShader(bool use_clip_planes, bool separable_shader) {
-    std::string out;
-    if (separable_shader) {
-        out += "#extension GL_ARB_separate_shader_objects : enable\n";
-    }
+        out +=
+                fmt::format("layout(location = {}) in vec4 vert_position;\n"
+                            "layout(location = {}) in vec4 vert_color;\n"
+                            "layout(location = {}) in vec2 vert_texcoord0;\n"
+                            "layout(location = {}) in vec2 vert_texcoord1;\n"
+                            "layout(location = {}) in vec2 vert_texcoord2;\n"
+                            "layout(location = {}) in float vert_texcoord0_w;\n"
+                            "layout(location = {}) in vec4 vert_normquat;\n"
+                            "layout(location = {}) in vec3 vert_view;\n",
+                            ATTRIBUTE_POSITION, ATTRIBUTE_COLOR, ATTRIBUTE_TEXCOORD0, ATTRIBUTE_TEXCOORD1,
+                            ATTRIBUTE_TEXCOORD2, ATTRIBUTE_TEXCOORD0_W, ATTRIBUTE_NORMQUAT, ATTRIBUTE_VIEW);
 
-    out +=
-        fmt::format("layout(location = {}) in vec4 vert_position;\n"
-                    "layout(location = {}) in vec4 vert_color;\n"
-                    "layout(location = {}) in vec2 vert_texcoord0;\n"
-                    "layout(location = {}) in vec2 vert_texcoord1;\n"
-                    "layout(location = {}) in vec2 vert_texcoord2;\n"
-                    "layout(location = {}) in float vert_texcoord0_w;\n"
-                    "layout(location = {}) in vec4 vert_normquat;\n"
-                    "layout(location = {}) in vec3 vert_view;\n",
-                    ATTRIBUTE_POSITION, ATTRIBUTE_COLOR, ATTRIBUTE_TEXCOORD0, ATTRIBUTE_TEXCOORD1,
-                    ATTRIBUTE_TEXCOORD2, ATTRIBUTE_TEXCOORD0_W, ATTRIBUTE_NORMQUAT, ATTRIBUTE_VIEW);
+        out += GetVertexInterfaceDeclaration(true, use_clip_planes, separable_shader);
+        out += VSUniformBlockDef;
 
-    out += GetVertexInterfaceDeclaration(true, use_clip_planes, separable_shader);
-    out += VSUniformBlockDef;
-
-    out += R"(
+        out += R"(
 void main() {
     primary_color = vert_color;
     texcoord0 = vert_texcoord0;
@@ -126,15 +126,15 @@ void main() {
     vec4 vtx_pos = SanitizeVertex(vert_position);
 )";
 
-    if (!Settings::values.vr_use_immersive_mode.GetValue())
-    {
-        out+= "\ngl_Position = vec4(vtx_pos.x, vtx_pos.y, -vtx_pos.z, vtx_pos.w);\n";
-    } else {
-        out+= "\ngl_Position = vec4(vtx_pos.x / 3.0, vtx_pos.y / 3.0, -vtx_pos.z, vtx_pos.w);\n";
-    }
+        if (!Settings::values.vr_use_immersive_mode.GetValue())
+        {
+            out+= "\ngl_Position = vec4(vtx_pos.x, vtx_pos.y, -vtx_pos.z, vtx_pos.w);\n";
+        } else {
+            out+= "\ngl_Position = vec4(vtx_pos.x / 3.0, vtx_pos.y / 3.0, -vtx_pos.z, vtx_pos.w);\n";
+        }
 
-    if (use_clip_planes) {
-        out += R"(
+        if (use_clip_planes) {
+            out += R"(
         gl_ClipDistance[0] = -vtx_pos.z; // fixed PICA clipping plane z <= 0
         if (enable_clip1) {
             gl_ClipDistance[1] = dot(clip_coef, vtx_pos);
@@ -142,121 +142,235 @@ void main() {
             gl_ClipDistance[1] = 0.0;
         }
         )";
+        }
+
+        out += "}\n";
+
+        return out;
     }
 
-    out += "}\n";
-
-    return out;
-}
 
 
-
-std::string_view MakeLoadPrefix(AttribLoadFlags flag) {
-    if (True(flag & AttribLoadFlags::Float)) {
-        return "";
-    } else if (True(flag & AttribLoadFlags::Sint)) {
-        return "i";
-    } else if (True(flag & AttribLoadFlags::Uint)) {
-        return "u";
-    }
-    return "";
-}
-
-std::string GenerateVertexShader(const ShaderSetup& setup, const PicaVSConfig& config,
-                                 bool separable_shader) {
-    std::string out;
-    if (separable_shader) {
-        out += "#extension GL_ARB_separate_shader_objects : enable\n";
-    }
-
-    out += VSPicaUniformBlockDef;
-    out += VSUniformBlockDef;
-
-    std::array<bool, 16> used_regs{};
-    const auto get_input_reg = [&used_regs](u32 reg) {
-        ASSERT(reg < 16);
-        used_regs[reg] = true;
-        return fmt::format("vs_in_reg{}", reg);
-    };
-
-    const auto get_output_reg = [&](u32 reg) -> std::string {
-        ASSERT(reg < 16);
-        if (config.state.output_map[reg] < config.state.num_outputs) {
-            return fmt::format("vs_out_attr{}", config.state.output_map[reg]);
+    std::string_view MakeLoadPrefix(AttribLoadFlags flag) {
+        if (True(flag & AttribLoadFlags::Float)) {
+            return "";
+        } else if (True(flag & AttribLoadFlags::Sint)) {
+            return "i";
+        } else if (True(flag & AttribLoadFlags::Uint)) {
+            return "u";
         }
         return "";
-    };
-
-    auto program_source =
-        DecompileProgram(setup.program_code, setup.swizzle_data, config.state.main_offset,
-                         get_input_reg, get_output_reg, config.state.sanitize_mul);
-
-    if (program_source.empty()) {
-        return "";
     }
 
-    // input attributes declaration
-    for (std::size_t i = 0; i < used_regs.size(); ++i) {
-        if (used_regs[i]) {
-            const auto flags = config.state.load_flags[i];
-            const std::string_view prefix = MakeLoadPrefix(flags);
-            out +=
-                fmt::format("layout(location = {0}) in {1}vec4 vs_in_typed_reg{0};\n", i, prefix);
-            out += fmt::format("vec4 vs_in_reg{0};\n", i);
+    std::string GenerateVertexShader(const ShaderSetup& setup, const PicaVSConfig& config,
+                                     bool separable_shader) {
+        std::string out;
+        if (separable_shader) {
+            out += "#extension GL_ARB_separate_shader_objects : enable\n";
         }
-    }
-    out += '\n';
 
-    if (config.state.use_geometry_shader) {
-        // output attributes declaration
+        out += VSPicaUniformBlockDef;
+        out += VSUniformBlockDef;
+
+        std::array<bool, 16> used_regs{};
+        const auto get_input_reg = [&used_regs](u32 reg) {
+            ASSERT(reg < 16);
+            used_regs[reg] = true;
+            return fmt::format("vs_in_reg{}", reg);
+        };
+
+        const auto get_output_reg = [&](u32 reg) -> std::string {
+            ASSERT(reg < 16);
+            if (config.state.output_map[reg] < config.state.num_outputs) {
+                return fmt::format("vs_out_attr{}", config.state.output_map[reg]);
+            }
+            return "";
+        };
+
+        auto program_source =
+                DecompileProgram(setup.program_code, setup.swizzle_data, config.state.main_offset,
+                                 get_input_reg, get_output_reg, config.state.sanitize_mul);
+
+        if (program_source.empty()) {
+            return "";
+        }
+
+        // input attributes declaration
+        for (std::size_t i = 0; i < used_regs.size(); ++i) {
+            if (used_regs[i]) {
+                const auto flags = config.state.load_flags[i];
+                const std::string_view prefix = MakeLoadPrefix(flags);
+                out +=
+                        fmt::format("layout(location = {0}) in {1}vec4 vs_in_typed_reg{0};\n", i, prefix);
+                out += fmt::format("vec4 vs_in_reg{0};\n", i);
+            }
+        }
+        out += '\n';
+
+        if (config.state.use_geometry_shader) {
+            // output attributes declaration
+            for (u32 i = 0; i < config.state.num_outputs; ++i) {
+                if (separable_shader) {
+                    out += fmt::format("layout(location = {}) ", i);
+                }
+                out += fmt::format("out vec4 vs_out_attr{};\n", i);
+            }
+            out += "void EmitVtx() {}\n";
+        } else {
+            out += GetVertexInterfaceDeclaration(true, config.state.use_clip_planes, separable_shader);
+
+            // output attributes declaration
+            for (u32 i = 0; i < config.state.num_outputs; ++i) {
+                out += fmt::format("vec4 vs_out_attr{};\n", i);
+            }
+
+            const auto semantic =
+                    [&state = config.state](VSOutputAttributes::Semantic slot_semantic) -> std::string {
+                        const u32 slot = static_cast<u32>(slot_semantic);
+                        const u32 attrib = state.gs_state.semantic_maps[slot].attribute_index;
+                        const u32 comp = state.gs_state.semantic_maps[slot].component_index;
+                        if (attrib < state.gs_state.gs_output_attributes) {
+                            return fmt::format("vs_out_attr{}.{}", attrib, "xyzw"[comp]);
+                        }
+                        return "1.0";
+                    };
+
+            out += "vec4 GetVertexQuaternion() {\n";
+            out += "    return vec4(" + semantic(VSOutputAttributes::QUATERNION_X) + ", " +
+                   semantic(VSOutputAttributes::QUATERNION_Y) + ", " +
+                   semantic(VSOutputAttributes::QUATERNION_Z) + ", " +
+                   semantic(VSOutputAttributes::QUATERNION_W) + ");\n";
+            out += "}\n\n";
+
+            out += "void EmitVtx() {\n";
+            out += "    vec4 vtx_pos = vec4(" + semantic(VSOutputAttributes::POSITION_X) + ", " +
+                   semantic(VSOutputAttributes::POSITION_Y) + ", " +
+                   semantic(VSOutputAttributes::POSITION_Z) + ", " +
+                   semantic(VSOutputAttributes::POSITION_W) + ");\n";
+            out += "    vtx_pos = SanitizeVertex(vtx_pos);\n";
+            if (!Settings::values.vr_use_immersive_mode.GetValue())
+            {
+                out+= "    gl_Position = vec4(vtx_pos.x, vtx_pos.y, -vtx_pos.z, vtx_pos.w);\n";
+            }
+            else
+            {
+                out+= "    gl_Position = vec4(vtx_pos.x / 3.0, vtx_pos.y / 3.0, -vtx_pos.z, vtx_pos.w);\n";
+            }
+            if (config.state.use_clip_planes) {
+                out += "    gl_ClipDistance[0] = -vtx_pos.z;\n"; // fixed PICA clipping plane z <= 0
+                out += "    if (enable_clip1) {\n";
+                out += "        gl_ClipDistance[1] = dot(clip_coef, vtx_pos);\n";
+                out += "    } else {\n";
+                out += "        gl_ClipDistance[1] = 0.0;\n";
+                out += "    }\n\n";
+            }
+
+            out += "    normquat = GetVertexQuaternion();\n";
+            out += "    vec4 vtx_color = vec4(" + semantic(VSOutputAttributes::COLOR_R) + ", " +
+                   semantic(VSOutputAttributes::COLOR_G) + ", " +
+                   semantic(VSOutputAttributes::COLOR_B) + ", " +
+                   semantic(VSOutputAttributes::COLOR_A) + ");\n";
+            out += "    primary_color = min(abs(vtx_color), vec4(1.0));\n\n";
+
+            out += "    texcoord0 = vec2(" + semantic(VSOutputAttributes::TEXCOORD0_U) + ", " +
+                   semantic(VSOutputAttributes::TEXCOORD0_V) + ");\n";
+            out += "    texcoord1 = vec2(" + semantic(VSOutputAttributes::TEXCOORD1_U) + ", " +
+                   semantic(VSOutputAttributes::TEXCOORD1_V) + ");\n\n";
+
+            out += "    texcoord0_w = " + semantic(VSOutputAttributes::TEXCOORD0_W) + ";\n";
+            out += "    view = vec3(" + semantic(VSOutputAttributes::VIEW_X) + ", " +
+                   semantic(VSOutputAttributes::VIEW_Y) + ", " + semantic(VSOutputAttributes::VIEW_Z) +
+                   ");\n\n";
+
+            out += "    texcoord2 = vec2(" + semantic(VSOutputAttributes::TEXCOORD2_U) + ", " +
+                   semantic(VSOutputAttributes::TEXCOORD2_V) + ");\n\n";
+            out += "}\n";
+        }
+
+        out += "bool exec_shader();\n\n";
+
+        out += "\nvoid main() {\n";
+        for (std::size_t i = 0; i < used_regs.size(); ++i) {
+            if (used_regs[i]) {
+                out += fmt::format("vs_in_reg{0} = vec4(vs_in_typed_reg{0});\n", i);
+                if (True(config.state.load_flags[i] & AttribLoadFlags::ZeroW)) {
+                    out += fmt::format("vs_in_reg{0}.w = 0;\n", i);
+                }
+            }
+        }
         for (u32 i = 0; i < config.state.num_outputs; ++i) {
+            out += fmt::format("    vs_out_attr{} = vec4(0.0, 0.0, 0.0, 1.0);\n", i);
+        }
+        out += "\n    exec_shader();\n    EmitVtx();\n}\n\n";
+
+        out += program_source;
+
+        return out;
+    }
+
+    static std::string GetGSCommonSource(const PicaGSConfigState& state, bool separable_shader) {
+        std::string out = GetVertexInterfaceDeclaration(true, state.use_clip_planes, separable_shader);
+        out += VSUniformBlockDef;
+
+        out += '\n';
+        for (u32 i = 0; i < state.vs_output_attributes; ++i) {
             if (separable_shader) {
                 out += fmt::format("layout(location = {}) ", i);
             }
-            out += fmt::format("out vec4 vs_out_attr{};\n", i);
-        }
-        out += "void EmitVtx() {}\n";
-    } else {
-        out += GetVertexInterfaceDeclaration(true, config.state.use_clip_planes, separable_shader);
-
-        // output attributes declaration
-        for (u32 i = 0; i < config.state.num_outputs; ++i) {
-            out += fmt::format("vec4 vs_out_attr{};\n", i);
+            out += fmt::format("in vec4 vs_out_attr{}[];\n", i);
         }
 
-        const auto semantic =
-            [&state = config.state](VSOutputAttributes::Semantic slot_semantic) -> std::string {
+        out += R"(
+struct Vertex {
+)";
+        out += fmt::format("    vec4 attributes[{}];\n", state.gs_output_attributes);
+        out += "};\n\n";
+
+        const auto semantic = [&state](VSOutputAttributes::Semantic slot_semantic) -> std::string {
             const u32 slot = static_cast<u32>(slot_semantic);
-            const u32 attrib = state.gs_state.semantic_maps[slot].attribute_index;
-            const u32 comp = state.gs_state.semantic_maps[slot].component_index;
-            if (attrib < state.gs_state.gs_output_attributes) {
-                return fmt::format("vs_out_attr{}.{}", attrib, "xyzw"[comp]);
+            const u32 attrib = state.semantic_maps[slot].attribute_index;
+            const u32 comp = state.semantic_maps[slot].component_index;
+            if (attrib < state.gs_output_attributes) {
+                return fmt::format("vtx.attributes[{}].{}", attrib, "xyzw"[comp]);
             }
             return "1.0";
         };
 
-        out += "vec4 GetVertexQuaternion() {\n";
+        out += "vec4 GetVertexQuaternion(Vertex vtx) {\n";
         out += "    return vec4(" + semantic(VSOutputAttributes::QUATERNION_X) + ", " +
                semantic(VSOutputAttributes::QUATERNION_Y) + ", " +
                semantic(VSOutputAttributes::QUATERNION_Z) + ", " +
                semantic(VSOutputAttributes::QUATERNION_W) + ");\n";
         out += "}\n\n";
 
-        out += "void EmitVtx() {\n";
+        out += "void EmitVtx(Vertex vtx, bool quats_opposite) {\n";
         out += "    vec4 vtx_pos = vec4(" + semantic(VSOutputAttributes::POSITION_X) + ", " +
                semantic(VSOutputAttributes::POSITION_Y) + ", " +
                semantic(VSOutputAttributes::POSITION_Z) + ", " +
                semantic(VSOutputAttributes::POSITION_W) + ");\n";
         out += "    vtx_pos = SanitizeVertex(vtx_pos);\n";
-        if (!Settings::values.vr_use_immersive_mode.GetValue())
-        {
-              out+= "    gl_Position = vec4(vtx_pos.x, vtx_pos.y, -vtx_pos.z, vtx_pos.w);\n";
+        if (!Settings::values.vr_use_immersive_mode.GetValue()) {
+            out+= "    gl_Position = vec4(vtx_pos.x, vtx_pos.y, -vtx_pos.z, vtx_pos.w);\n";
+        } else {
+            out+= "    gl_Position = vec4(vtx_pos.x / 3.0, vtx_pos.y / 3.0, -vtx_pos.z, vtx_pos.w);\n";
+            // via https://github.com/lvonasek - https://github.com/DrBeef/CitraVR/commit/e97ca06b3d298c89518ce6779fa073e943577535#r138208138
+            out += R"(
+                // Viewport resize for immersive mode
+                gl_Position.xy /= vr_immersive_mode_factor;
+                //calculate 6DoF in the screen space
+                //(you would have to guess the projection matrix)
+                vec4 camera_offset = projection * vec4(vr_position, 1.0);
+
+                //do manually perspective division
+                gl_Position /= abs(gl_Position.w);
+                camera_offset /= abs(camera_offset.w);
+
+                //add the offset
+                gl_Position.xyz += camera_offset.xyz;
+            )";
         }
-        else
-        {
-              out+= "    gl_Position = vec4(vtx_pos.x / 3.0, vtx_pos.y / 3.0, -vtx_pos.z, vtx_pos.w);\n";
-        }
-        if (config.state.use_clip_planes) {
+
+        if (state.use_clip_planes) {
             out += "    gl_ClipDistance[0] = -vtx_pos.z;\n"; // fixed PICA clipping plane z <= 0
             out += "    if (enable_clip1) {\n";
             out += "        gl_ClipDistance[1] = dot(clip_coef, vtx_pos);\n";
@@ -265,11 +379,12 @@ std::string GenerateVertexShader(const ShaderSetup& setup, const PicaVSConfig& c
             out += "    }\n\n";
         }
 
-        out += "    normquat = GetVertexQuaternion();\n";
+        out += "    vec4 vtx_quat = GetVertexQuaternion(vtx);\n";
+        out += "    normquat = mix(vtx_quat, -vtx_quat, bvec4(quats_opposite));\n\n";
+
         out += "    vec4 vtx_color = vec4(" + semantic(VSOutputAttributes::COLOR_R) + ", " +
-               semantic(VSOutputAttributes::COLOR_G) + ", " +
-               semantic(VSOutputAttributes::COLOR_B) + ", " +
-               semantic(VSOutputAttributes::COLOR_A) + ");\n";
+               semantic(VSOutputAttributes::COLOR_G) + ", " + semantic(VSOutputAttributes::COLOR_B) +
+               ", " + semantic(VSOutputAttributes::COLOR_A) + ");\n";
         out += "    primary_color = min(abs(vtx_color), vec4(1.0));\n\n";
 
         out += "    texcoord0 = vec2(" + semantic(VSOutputAttributes::TEXCOORD0_U) + ", " +
@@ -284,111 +399,11 @@ std::string GenerateVertexShader(const ShaderSetup& setup, const PicaVSConfig& c
 
         out += "    texcoord2 = vec2(" + semantic(VSOutputAttributes::TEXCOORD2_U) + ", " +
                semantic(VSOutputAttributes::TEXCOORD2_V) + ");\n\n";
+
+        out += "    EmitVertex();\n";
         out += "}\n";
-    }
 
-    out += "bool exec_shader();\n\n";
-
-    out += "\nvoid main() {\n";
-    for (std::size_t i = 0; i < used_regs.size(); ++i) {
-        if (used_regs[i]) {
-            out += fmt::format("vs_in_reg{0} = vec4(vs_in_typed_reg{0});\n", i);
-            if (True(config.state.load_flags[i] & AttribLoadFlags::ZeroW)) {
-                out += fmt::format("vs_in_reg{0}.w = 0;\n", i);
-            }
-        }
-    }
-    for (u32 i = 0; i < config.state.num_outputs; ++i) {
-        out += fmt::format("    vs_out_attr{} = vec4(0.0, 0.0, 0.0, 1.0);\n", i);
-    }
-    out += "\n    exec_shader();\n    EmitVtx();\n}\n\n";
-
-    out += program_source;
-
-    return out;
-}
-
-static std::string GetGSCommonSource(const PicaGSConfigState& state, bool separable_shader) {
-    std::string out = GetVertexInterfaceDeclaration(true, state.use_clip_planes, separable_shader);
-    out += VSUniformBlockDef;
-
-    out += '\n';
-    for (u32 i = 0; i < state.vs_output_attributes; ++i) {
-        if (separable_shader) {
-            out += fmt::format("layout(location = {}) ", i);
-        }
-        out += fmt::format("in vec4 vs_out_attr{}[];\n", i);
-    }
-
-    out += R"(
-struct Vertex {
-)";
-    out += fmt::format("    vec4 attributes[{}];\n", state.gs_output_attributes);
-    out += "};\n\n";
-
-    const auto semantic = [&state](VSOutputAttributes::Semantic slot_semantic) -> std::string {
-        const u32 slot = static_cast<u32>(slot_semantic);
-        const u32 attrib = state.semantic_maps[slot].attribute_index;
-        const u32 comp = state.semantic_maps[slot].component_index;
-        if (attrib < state.gs_output_attributes) {
-            return fmt::format("vtx.attributes[{}].{}", attrib, "xyzw"[comp]);
-        }
-        return "1.0";
-    };
-
-    out += "vec4 GetVertexQuaternion(Vertex vtx) {\n";
-    out += "    return vec4(" + semantic(VSOutputAttributes::QUATERNION_X) + ", " +
-           semantic(VSOutputAttributes::QUATERNION_Y) + ", " +
-           semantic(VSOutputAttributes::QUATERNION_Z) + ", " +
-           semantic(VSOutputAttributes::QUATERNION_W) + ");\n";
-    out += "}\n\n";
-
-    out += "void EmitVtx(Vertex vtx, bool quats_opposite) {\n";
-    out += "    vec4 vtx_pos = vec4(" + semantic(VSOutputAttributes::POSITION_X) + ", " +
-           semantic(VSOutputAttributes::POSITION_Y) + ", " +
-           semantic(VSOutputAttributes::POSITION_Z) + ", " +
-           semantic(VSOutputAttributes::POSITION_W) + ");\n";
-    out += "    vtx_pos = SanitizeVertex(vtx_pos);\n";
-    if (!Settings::values.vr_use_immersive_mode.GetValue()) {
-        out+= "    gl_Position = vec4(vtx_pos.x, vtx_pos.y, -vtx_pos.z, vtx_pos.w);\n";
-    } else {
-        out+= "    gl_Position = vec4(vtx_pos.x / 3.0, vtx_pos.y / 3.0, -vtx_pos.z, vtx_pos.w);\n";
-    }
-
-    if (state.use_clip_planes) {
-        out += "    gl_ClipDistance[0] = -vtx_pos.z;\n"; // fixed PICA clipping plane z <= 0
-        out += "    if (enable_clip1) {\n";
-        out += "        gl_ClipDistance[1] = dot(clip_coef, vtx_pos);\n";
-        out += "    } else {\n";
-        out += "        gl_ClipDistance[1] = 0.0;\n";
-        out += "    }\n\n";
-    }
-
-    out += "    vec4 vtx_quat = GetVertexQuaternion(vtx);\n";
-    out += "    normquat = mix(vtx_quat, -vtx_quat, bvec4(quats_opposite));\n\n";
-
-    out += "    vec4 vtx_color = vec4(" + semantic(VSOutputAttributes::COLOR_R) + ", " +
-           semantic(VSOutputAttributes::COLOR_G) + ", " + semantic(VSOutputAttributes::COLOR_B) +
-           ", " + semantic(VSOutputAttributes::COLOR_A) + ");\n";
-    out += "    primary_color = min(abs(vtx_color), vec4(1.0));\n\n";
-
-    out += "    texcoord0 = vec2(" + semantic(VSOutputAttributes::TEXCOORD0_U) + ", " +
-           semantic(VSOutputAttributes::TEXCOORD0_V) + ");\n";
-    out += "    texcoord1 = vec2(" + semantic(VSOutputAttributes::TEXCOORD1_U) + ", " +
-           semantic(VSOutputAttributes::TEXCOORD1_V) + ");\n\n";
-
-    out += "    texcoord0_w = " + semantic(VSOutputAttributes::TEXCOORD0_W) + ";\n";
-    out += "    view = vec3(" + semantic(VSOutputAttributes::VIEW_X) + ", " +
-           semantic(VSOutputAttributes::VIEW_Y) + ", " + semantic(VSOutputAttributes::VIEW_Z) +
-           ");\n\n";
-
-    out += "    texcoord2 = vec2(" + semantic(VSOutputAttributes::TEXCOORD2_U) + ", " +
-           semantic(VSOutputAttributes::TEXCOORD2_V) + ");\n\n";
-
-    out += "    EmitVertex();\n";
-    out += "}\n";
-
-    out += R"(
+        out += R"(
 bool AreQuaternionsOpposite(vec4 qa, vec4 qb) {
     return (dot(qa, qb) < 0.0);
 }
@@ -401,38 +416,38 @@ void EmitPrim(Vertex vtx0, Vertex vtx1, Vertex vtx2) {
 }
 )";
 
-    return out;
-};
+        return out;
+    };
 
-std::string GenerateFixedGeometryShader(const PicaFixedGSConfig& config, bool separable_shader) {
-    std::string out;
-    if (separable_shader) {
-        out += "#extension GL_ARB_separate_shader_objects : enable\n";
-    }
+    std::string GenerateFixedGeometryShader(const PicaFixedGSConfig& config, bool separable_shader) {
+        std::string out;
+        if (separable_shader) {
+            out += "#extension GL_ARB_separate_shader_objects : enable\n";
+        }
 
-    out += R"(
+        out += R"(
 layout(triangles) in;
 layout(triangle_strip, max_vertices = 3) out;
 
 )";
 
-    out += GetGSCommonSource(config.state, separable_shader);
+        out += GetGSCommonSource(config.state, separable_shader);
 
-    out += R"(
+        out += R"(
 void main() {
     Vertex prim_buffer[3];
 )";
-    for (u32 vtx = 0; vtx < 3; ++vtx) {
-        out += fmt::format("    prim_buffer[{}].attributes = vec4[{}](", vtx,
-                           config.state.gs_output_attributes);
-        for (u32 i = 0; i < config.state.vs_output_attributes; ++i) {
-            out += fmt::format("{}vs_out_attr{}[{}]", i == 0 ? "" : ", ", i, vtx);
+        for (u32 vtx = 0; vtx < 3; ++vtx) {
+            out += fmt::format("    prim_buffer[{}].attributes = vec4[{}](", vtx,
+                               config.state.gs_output_attributes);
+            for (u32 i = 0; i < config.state.vs_output_attributes; ++i) {
+                out += fmt::format("{}vs_out_attr{}[{}]", i == 0 ? "" : ", ", i, vtx);
+            }
+            out += ");\n";
         }
-        out += ");\n";
-    }
-    out += "    EmitPrim(prim_buffer[0], prim_buffer[1], prim_buffer[2]);\n";
-    out += "}\n";
+        out += "    EmitPrim(prim_buffer[0], prim_buffer[1], prim_buffer[2]);\n";
+        out += "}\n";
 
-    return out;
-}
+        return out;
+    }
 } // namespace Pica::Shader::Generator::GLSL


### PR DESCRIPTION
all i did was copy @DrBeef's `immersive_tweaks_2` work back on top of @amwatson's master branch update
it's _almost_ working but:
- ❌ it's got a shader bug that i haven't had time to trace yet (karts + characters missing in mk7) 
- ✅ ✅ mk7 & shovel knight load on QP
- ❓ ❌ haven't tried Q3, sounds broken on Q2
- ❌ _release_ build crashes immediately 
- ✅ _canaryWithDebInfo_ does not crash, but is not most optimal version of binary producible (right?, file size is like 10mb less)

- 🤩 i increased max depth to 300 from 100 (i LOVE this change and want to try 1000 for giggles, what's the upper limit before i flip inside out?) (i also want an option to BACKWARDS map it onto a little mini-planet hemi-sphere/dome like those insta360 fisheye videos)
- started carrying over dr beefs changes from immersive tweaks 2 (with lubos ADDITIONAL suggestions)
- commented out disabling passthru w/ immersive, i'd like the option to leave it enabled
- ❌ 6dof head movement isn't affecting emulator video output