### PR TITLE
Fix VR view in latest QuestOS

### DIFF
--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -130,6 +130,7 @@
             android:screenOrientation="landscape"
             android:theme="@style/VRTheme">
             <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
                 <category android:name="com.oculus.intent.category.VR" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>


### PR DESCRIPTION
Fixes #76 and #75

Since Quest OS v66, the transition to the VR view doesn't work, and the input from the quest controllers doesn't work either; this change fixes both.

I think it would be a good moment to make a new release; current releases don't work at all with the latest Quest OS.

Thanks a lot for your hard work on this project @amwatson, it's awesome!!