### PR TITLE
Fix content not showing in some versions of HorizonOS

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/vr/ui/VrUILayer.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/vr/ui/VrUILayer.kt
@@ -15,8 +15,10 @@ import android.view.MotionEvent.PointerCoords
 import android.view.MotionEvent.PointerProperties
 import android.view.Surface
 import android.view.View
+import android.view.ViewGroup
 import android.view.Window
 import android.view.WindowManager
+import android.widget.FrameLayout
 import org.citra.citra_emu.utils.Log
 import org.citra.citra_emu.vr.VrActivity
 import java.io.File
@@ -39,6 +41,7 @@ abstract class VrUILayer(
     private val requestedDensity: Float = densityDpi.toFloat()
     private var virtualDisplay: VirtualDisplay? = null
     private var presentation: Presentation? = null
+    private var surfaceHeightDp: Int = 0
 
     val window: Window?
         get() = presentation!!.window
@@ -104,7 +107,7 @@ abstract class VrUILayer(
             }),
             arrayOf(PointerCoords().apply {
                 this.x = x
-                this.y = y
+                this.y = surfaceHeightDp - y
                 pressure = 1f
                 size = 1f
             }),
@@ -127,6 +130,7 @@ abstract class VrUILayer(
         surface: Surface, widthDp: Int,
         heightDp: Int
     ) {
+        surfaceHeightDp = heightDp
         // Create a virtual display based on the exact dimensions needed for the view
         val displayManager = activity.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
         virtualDisplay = displayManager.createVirtualDisplay(
@@ -135,7 +139,24 @@ abstract class VrUILayer(
         )
         presentation = Presentation(activity.applicationContext, virtualDisplay!!.display).apply {
             window?.setType(WindowManager.LayoutParams.TYPE_PRIVATE_PRESENTATION)
-            setContentView(layoutId)
+            val contentView = LayoutInflater.from(context).inflate(layoutId, null, false).apply {
+                pivotY = 0f
+                scaleY = -1f
+                translationY = heightDp.toFloat()
+            }
+            val root = FrameLayout(context).apply {
+                clipChildren = false
+                clipToPadding = false
+                layoutParams = ViewGroup.LayoutParams(widthDp, heightDp)
+                addView(
+                    contentView,
+                    FrameLayout.LayoutParams(
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                    )
+                )
+            }
+            setContentView(root)
             // Sets the background to transparent. Remove to set background to white
             // (useful for catching overrendering)
             window?.setBackgroundDrawable(ColorDrawable(0))

--- a/src/android/app/src/main/jni/vr/layers/GameSurfaceLayer.cpp
+++ b/src/android/app/src/main/jni/vr/layers/GameSurfaceLayer.cpp
@@ -218,7 +218,7 @@ XrVector2f GetDensityScaleForSize(const int32_t  texWidth,
                                   const uint32_t resolutionFactor) {
     const float density = GetDensitySysprop(resolutionFactor);
     return XrVector2f{2.0f * static_cast<float>(texWidth) / density,
-                      (static_cast<float>(texHeight) / density)} *
+                      (static_cast<float>(std::abs(texHeight)) / density)} *
            scaleFactor;
 }
 
@@ -327,7 +327,7 @@ void GameSurfaceLayer::FrameTopPanel(const XrSpace& space, std::vector<XrComposi
                                  : GameSurfaceLayer::DEFAULT_CYLINDER_CENTRAL_ANGLE_DEGREES *
                                        immersiveModeFactor) *
                 MATH_FLOAT_PI / 180.0f;
-            layer.aspectRatio              = -static_cast<double>(mTopPanel.AspectRatio());
+            layer.aspectRatio              = static_cast<double>(mTopPanel.AspectRatio());
             layers[layerCount++].mCylinder = layer;
         }
     } else {
@@ -356,7 +356,7 @@ void GameSurfaceLayer::FrameTopPanel(const XrSpace& space, std::vector<XrComposi
             // Scale to get the desired density within the visible area (if we
             // want).
             const auto scale  = GetDensityScaleForSize(mTopPanel.mWidth - cropHoriz,
-                                                       -mTopPanel.mHeight, 1.0f, mResolutionFactor);
+                                                       mTopPanel.mHeight, 1.0f, mResolutionFactor);
             layer.size.width  = scale.x;
             layer.size.height = scale.y;
 
@@ -401,7 +401,7 @@ void GameSurfaceLayer::FrameLowerPanel(const XrSpace&                   space,
     layer.subImage.imageRect.extent.height = mLowerPanel.mHeight / immersiveModeFactor;
     layer.subImage.imageArrayIndex         = 0;
     layer.pose                             = mLowerPanel.mWorldFromPanel;
-    const auto scale  = GetDensityScaleForSize(mLowerPanel.mWidth - cropHoriz, -mLowerPanel.mHeight,
+    const auto scale  = GetDensityScaleForSize(mLowerPanel.mWidth - cropHoriz, mLowerPanel.mHeight,
                                                mLowerPanel.mScaleFactor, mResolutionFactor);
     layer.size.width  = scale.x;
     layer.size.height = scale.y;

--- a/src/android/app/src/main/jni/vr/layers/UILayer.cpp
+++ b/src/android/app/src/main/jni/vr/layers/UILayer.cpp
@@ -199,7 +199,7 @@ void UILayer::Frame(const XrSpace&                   space,
     layer.subImage.imageRect.extent.height = mSwapchain.mHeight;
     layer.subImage.imageArrayIndex         = 0;
     layer.pose                             = mWorldFromPanel;
-    const auto scale  = GetDensityScaleForSize(mSwapchain.mWidth, -mSwapchain.mHeight, 1.0f);
+    const auto scale  = GetDensityScaleForSize(mSwapchain.mWidth, mSwapchain.mHeight, 1.0f);
     layer.size.width  = scale.x;
     layer.size.height = scale.y;
     layers[layerCount++].mQuad = layer;

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -72,6 +72,10 @@ static std::array<GLfloat, 3 * 2> MakeOrthographicMatrix(const float width, cons
     return matrix;
 }
 
+void ApplyVrAtlasFlip(const float& top, const float& bottom) {
+    std::swap(const_cast<float&>(top), const_cast<float&>(bottom));
+}
+
 RendererOpenGL::RendererOpenGL(Core::System& system, Pica::PicaCore& pica_,
                                Frontend::EmuWindow& window, Frontend::EmuWindow* secondary_window)
     : VideoCore::RendererBase{system, window, secondary_window}, pica{pica_},
@@ -523,6 +527,7 @@ void RendererOpenGL::ConfigureFramebufferTexture(TextureInfo& texture,
 void RendererOpenGL::DrawSingleScreen(const ScreenInfo& screen_info, float x, float y, float w,
                                       float h, Layout::DisplayOrientation orientation) {
     const auto& texcoords = screen_info.display_texcoords;
+    ApplyVrAtlasFlip(texcoords.top, texcoords.bottom);
 
     std::array<ScreenRectVertex, 4> vertices;
     switch (orientation) {
@@ -594,6 +599,7 @@ void RendererOpenGL::DrawSingleScreenStereo(const ScreenInfo& screen_info_l,
                                             float w, float h,
                                             Layout::DisplayOrientation orientation) {
     const auto& texcoords = screen_info_l.display_texcoords;
+    ApplyVrAtlasFlip(texcoords.top, texcoords.bottom);
 
     std::array<ScreenRectVertex, 4> vertices;
     switch (orientation) {

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -50,6 +50,10 @@ constexpr static std::array<vk::DescriptorSetLayoutBinding, 1> PRESENT_BINDINGS 
     {0, vk::DescriptorType::eCombinedImageSampler, 3, vk::ShaderStageFlagBits::eFragment},
 }};
 
+void ApplyVrAtlasFlip(const float& top, const float& bottom) {
+    std::swap(const_cast<float&>(top), const_cast<float&>(bottom));
+}
+
 RendererVulkan::RendererVulkan(Core::System& system, Pica::PicaCore& pica_,
                                Frontend::EmuWindow& window, Frontend::EmuWindow* secondary_window)
     : RendererBase{system, window, secondary_window}, memory{system.Memory()}, pica{pica_},
@@ -531,6 +535,7 @@ void RendererVulkan::DrawSingleScreen(u32 screen_id, float x, float y, float w, 
                                       Layout::DisplayOrientation orientation) {
     const ScreenInfo& screen_info = screen_infos[screen_id];
     const auto& texcoords = screen_info.texcoords;
+    ApplyVrAtlasFlip(texcoords.top, texcoords.bottom);
 
     std::array<ScreenRectVertex, 4> vertices;
     switch (orientation) {
@@ -603,6 +608,7 @@ void RendererVulkan::DrawSingleScreenStereo(u32 screen_id_l, u32 screen_id_r, fl
                                             Layout::DisplayOrientation orientation) {
     const ScreenInfo& screen_info_l = screen_infos[screen_id_l];
     const auto& texcoords = screen_info_l.texcoords;
+    ApplyVrAtlasFlip(texcoords.top, texcoords.bottom);
 
     std::array<ScreenRectVertex, 4> vertices;
     switch (orientation) {


### PR DESCRIPTION
Includes 2 commits, 5dc4ca4ae1afb410fc158e96ca50bf84597dba88 fixes immersive mode not showing the upper screen (teleported into black void).

91131c61384f012e7df4722b797dc3bf3e3721bd seemingly fixed a similar issue for regular mode, but I'm no longer able reproduce the issue.  Dropping the commit made no difference in my testing. Including for completeness.